### PR TITLE
CORS support

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/controller/PingEndpoint.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/controller/PingEndpoint.java
@@ -1,11 +1,13 @@
 package uk.gov.justice.probation.courtcasematcher.controller;
 
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class PingEndpoint {
 
+    @CrossOrigin
     @RequestMapping(value = "/ping")
     public String ping() {
         return "pong";


### PR DESCRIPTION
Allows Cross-origin resource sharingCross-origin resource sharing on /ping endpoint so that health check can be hit from Frontend code (such as build radiator).