### PR TITLE
:sparkles: Post matches result to court case service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
     implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0.1'
     compile 'org.glassfish.jaxb:jaxb-runtime:2.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-artemis'
+    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0'
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0'
 
     compile 'org.springframework.boot:spring-boot-starter-webflux'
     compile 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
@@ -87,10 +90,7 @@ dependencies {
     testCompile group: 'commons-io', name: 'commons-io', version: '2.6'
     testRuntimeOnly 'org.apache.activemq:activemq-broker:5.15.3'
 
-    // Added temporarily for message processing from gateway
-    implementation 'org.springframework.boot:spring-boot-starter-artemis'
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0'
+    testCompile 'org.apache.activemq:artemis-junit:2.13.0'
 
 }
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/CourtCase.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/CourtCase.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcasematcher.model.courtcaseservice;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -59,5 +60,8 @@ public class CourtCase implements Serializable {
     private final Boolean breach;
 
     private final Boolean suspendedSentenceOrder;
+
+    @JsonIgnore
+    private final GroupedOffenderMatches groupedOffenderMatches;
 
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/GroupedOffenderMatches.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/GroupedOffenderMatches.java
@@ -1,0 +1,22 @@
+package uk.gov.justice.probation.courtcasematcher.model.courtcaseservice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Data
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+public class GroupedOffenderMatches {
+    @NotNull
+    @JsonProperty("matches")
+    @Valid
+    private final List<OffenderMatch> matches;
+}

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/MatchIdentifiers.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/MatchIdentifiers.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.probation.courtcasematcher.model.courtcaseservice;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Data
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+public class MatchIdentifiers {
+    @NotNull
+    private final String crn;
+    private final String pnc;
+    private final String cro;
+}

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/OffenderMatch.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/OffenderMatch.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.probation.courtcasematcher.model.courtcaseservice;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
+
+@AllArgsConstructor
+@Builder
+@Data
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+public class OffenderMatch {
+    @NotNull
+    @Valid
+    private final MatchIdentifiers matchIdentifiers;
+    @NotNull
+    private final MatchType matchType;
+    @NotNull
+    private final Boolean confirmed;
+}

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.justice.probation.courtcasematcher.application.CaseMapperReference;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Address;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Offence;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
@@ -98,11 +99,12 @@ public class CaseMapper {
             .build();
     }
 
-    public CourtCase newFromCaseAndOffender(Case incomingCase, Offender offender) {
+    public CourtCase newFromCaseAndOffender(Case incomingCase, Offender offender, GroupedOffenderMatches groupedOffenderMatches) {
         return getCourtCaseBuilderFromCase(incomingCase)
                 .crn(offender.getOtherIds().getCrn())
                 .cro(offender.getOtherIds().getCro())
                 .pnc(offender.getOtherIds().getPnc())
+                .groupedOffenderMatches(groupedOffenderMatches)
                 .build();
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/MatchType.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/MatchType.java
@@ -1,17 +1,14 @@
 package uk.gov.justice.probation.courtcasematcher.model.offendersearch;
 
 public enum MatchType {
-    /**
-     * This is how offender search describes the search, not used to store offender matches against.
-     */
-    ALL_SUPPLIED,
-    NAME_DOB,
-    HMPPS_KEY,
-    EXTERNAL_KEY,
-    NAME,
-    PARTIAL_NAME,
-    PARTIAL_NAME_DOB_LENIENT,
-    NOTHING
+    NAME_DOB;
 
-
+    public static MatchType of(OffenderSearchMatchType offenderSearchMatchType) {
+        switch (offenderSearchMatchType) {
+            case ALL_SUPPLIED:
+                return NAME_DOB;
+            default:
+                return null;
+        }
+    }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/MatchType.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/MatchType.java
@@ -1,11 +1,17 @@
 package uk.gov.justice.probation.courtcasematcher.model.offendersearch;
 
 public enum MatchType {
+    /**
+     * This is how offender search describes the search, not used to store offender matches against.
+     */
     ALL_SUPPLIED,
+    NAME_DOB,
     HMPPS_KEY,
     EXTERNAL_KEY,
     NAME,
     PARTIAL_NAME,
     PARTIAL_NAME_DOB_LENIENT,
     NOTHING
+
+
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/OffenderSearchMatchType.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/OffenderSearchMatchType.java
@@ -1,0 +1,12 @@
+package uk.gov.justice.probation.courtcasematcher.model.offendersearch;
+
+public enum OffenderSearchMatchType {
+    ALL_SUPPLIED,
+    HMPPS_KEY,
+    EXTERNAL_KEY,
+    NAME,
+    PARTIAL_NAME,
+    PARTIAL_NAME_DOB_LENIENT,
+    NOTHING
+
+}

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
@@ -10,5 +10,5 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class SearchResponse {
     private final List<Match> matches;
-    private final MatchType matchedBy;
+    private final OffenderSearchMatchType matchedBy;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
@@ -1,10 +1,13 @@
 package uk.gov.justice.probation.courtcasematcher.restclient;
 
 import com.google.common.eventbus.EventBus;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -16,19 +19,20 @@ import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseSuccessEvent;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
 import uk.gov.justice.probation.courtcasematcher.restclient.exception.CourtCaseNotFoundException;
-
-import java.nio.charset.StandardCharsets;
 
 @Component
 @Slf4j
 public class CourtCaseRestClient {
 
-    private static final String ERROR_MSG_FORMAT = "Unexpected exception when applying PUT to update case number '%s' for court '%s'";
-    private static final String PUT_404_MSG_FORMAT = "PUT of case no '%s' for court '%s' failed. Http status '%s'. Likely an incorrect court code.";
+    private static final String ERR_MSG_FORMAT_PUT_CASE = "Unexpected exception when applying PUT to update case number '%s' for court '%s'";
+    private static final String ERR_MSG_FORMAT_POST_MATCH = "Unexpected exception when POST matches for case number '%s' for court '%s'";
 
     @Value("${court-case-service.case-put-url-template}")
     private String courtCasePutTemplate;
+    @Value("${court-case-service.matches-post-url-template}")
+    private String matchesPostTemplate;
 
     private final EventBus eventBus;
 
@@ -64,10 +68,24 @@ public class CourtCaseRestClient {
 
         return put(path, courtCase)
             .retrieve()
-            .onStatus(HttpStatus::isError, (clientResponse) -> handlePutError(clientResponse, courtCode, caseNo))
+            .onStatus(HttpStatus::isError, (clientResponse) -> handleError(clientResponse, courtCode, caseNo))
             .bodyToMono(CourtCase.class)
-            .doOnError(e -> postErrorToBus(String.format(ERROR_MSG_FORMAT, caseNo, courtCode) + ".Exception : " + e))
+            .doOnError(e -> postErrorToBus(String.format(ERR_MSG_FORMAT_PUT_CASE, caseNo, courtCode) + ".Exception : " + e))
             .subscribe(courtCaseApi -> eventBus.post(CourtCaseSuccessEvent.builder().courtCaseApi(courtCaseApi).build()));
+    }
+
+    public Disposable postMatches(String courtCode, String caseNo, GroupedOffenderMatches offenderMatches) {
+        final String path = String.format(matchesPostTemplate, courtCode, caseNo);
+
+        return post(path, offenderMatches)
+            .retrieve()
+            .onStatus(HttpStatus::isError, (clientResponse) -> handleError(clientResponse, courtCode, caseNo))
+            .toBodilessEntity()
+            .doOnError(e -> log.error(String.format(ERR_MSG_FORMAT_POST_MATCH, caseNo, courtCode) + ".Exception : " + e))
+            .subscribe(responseEntity -> {
+                log.info("Successful POST of offender matches. Response location: {} ",
+                    Optional.ofNullable(responseEntity.getHeaders().getFirst(HttpHeaders.LOCATION)).orElse("[NOT FOUND]"));
+            });
     }
 
     private WebClient.RequestHeadersSpec<?> get(String path) {
@@ -85,6 +103,14 @@ public class CourtCaseRestClient {
             .accept(MediaType.APPLICATION_JSON);
     }
 
+    private WebClient.RequestHeadersSpec<?> post(String path, GroupedOffenderMatches request) {
+        return webClient
+            .post()
+            .uri(uriBuilder -> uriBuilder.path(path).build())
+            .body(Mono.just(request), GroupedOffenderMatches.class)
+            .accept(MediaType.APPLICATION_JSON);
+    }
+
     private Mono<? extends Throwable> handleGetError(ClientResponse clientResponse, String courtCode, String caseNo) {
         final HttpStatus httpStatus = clientResponse.statusCode();
         // This is expected for new cases
@@ -99,7 +125,7 @@ public class CourtCaseRestClient {
             StandardCharsets.UTF_8);
     }
 
-    private Mono<? extends Throwable> handlePutError(ClientResponse clientResponse, String courtCode, String caseNo) {
+    private Mono<? extends Throwable> handleError(ClientResponse clientResponse, String courtCode, String caseNo) {
         final HttpStatus httpStatus = clientResponse.statusCode();
         if (HttpStatus.NOT_FOUND.equals(httpStatus)) {
             return Mono.error(new CourtCaseNotFoundException(courtCode, caseNo));

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.probation.courtcasematcher.service;
 
+import static uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType.ALL_SUPPLIED;
+
 import java.util.Collections;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -53,7 +55,7 @@ public class MatcherService {
                         caseNo, courtCode, searchResponse.getMatchedBy(), searchResponse.getMatches() == null ? "null" : searchResponse.getMatches().size()));
                     return searchResponse;
                 })
-                .filter(searchResponse -> searchResponse.getMatchedBy() == MatchType.ALL_SUPPLIED)
+                .filter(searchResponse -> searchResponse.getMatchedBy() == ALL_SUPPLIED)
                 .map(SearchResponse::getMatches)
                 .flatMap(matches -> {
                     if (matches != null && matches.size() == 1)
@@ -61,7 +63,7 @@ public class MatcherService {
                     else
                         return Mono.empty();
                 })
-                .map( match -> caseMapper.newFromCaseAndOffender(incomingCase, match.getOffender(), buildGroupedOffenderMatch(match, MatchType.NAME_DOB)))
+                .map( match -> caseMapper.newFromCaseAndOffender(incomingCase, match.getOffender(), buildGroupedOffenderMatch(match, MatchType.of(ALL_SUPPLIED))))
                 // Ideally we would avoid blocking at this point and continue with Mono processing
                 .doOnSuccess((data) -> {
                     if (data == null) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,7 +22,7 @@ cgi:
 spring:
   artemis:
     mode: native
-    host: "crime-portal-mirror-gateway-jms.crime-portal-mirror-gateway-dev"
+    host: ${GATEWAY_JMS_HOST:crime-portal-mirror-gateway-jms}
     user: ${GATEWAY_JMS_USERNAME}
     password: ${GATEWAY_JMS_PASSWORD}
     port: ${GATEWAY_JMS_PORT:5445}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ spring:
 
 court-case-service:
   case-put-url-template: /court/%s/case/%s
+  matches-post-url-template: /court/%s/case/%s/grouped-offender-matches
 
 offender-search:
   post-match-url: /match

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
@@ -5,17 +5,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.slf4j.LoggerFactory.getLogger;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.eventbus.EventBus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -25,7 +38,11 @@ import uk.gov.justice.probation.courtcasematcher.event.CourtCaseFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseSuccessEvent;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Address;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.MatchIdentifiers;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Offence;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderMatch;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -43,6 +60,12 @@ public class CourtCaseRestClientIntTest {
         .courtCode(COURT_CODE)
         .build();
 
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> captorLoggingEvent;
+
     @MockBean
     private EventBus eventBus;
 
@@ -53,6 +76,14 @@ public class CourtCaseRestClientIntTest {
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
             .port(8090)
             .usingFilesUnderClasspath("mocks"));
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        Logger logger = (Logger) getLogger(LoggerFactory.getLogger(CourtCaseRestClient.class).getName());
+        logger.addAppender(mockAppender);
+    }
+
 
     @Test
     public void whenGetCourtCase_thenMakeRestCallToCourtCaseService() {
@@ -133,4 +164,79 @@ public class CourtCaseRestClientIntTest {
         verify(eventBus, timeout(WEB_CLIENT_TIMEOUT_MS)).post(any(CourtCaseFailureEvent.class));
     }
 
+    @Test
+    public void whenPostOffenderMatches_thenMakeRestCallToCourtCaseService() {
+
+        GroupedOffenderMatches matches = GroupedOffenderMatches.builder()
+            .matches(Collections.singletonList(OffenderMatch.builder()
+                                                .matchType(MatchType.ALL_SUPPLIED)
+                                                .matchIdentifiers(MatchIdentifiers.builder()
+                                                    .crn("X123456")
+                                                    .cro("E1324/11")
+                                                    .pnc("PNC")
+                                                    .build())
+                                                .build()))
+            .build();
+
+        restClient.postMatches(COURT_CODE, CASE_NO, matches);
+
+        verify(mockAppender, timeout(WEB_CLIENT_TIMEOUT_MS)).doAppend(captorLoggingEvent.capture());
+
+        List<LoggingEvent> events = captorLoggingEvent.getAllValues();
+        LoggingEvent loggingEvent = events.get(0);
+        assertThat(loggingEvent.getLevel()).isEqualTo(Level.INFO);
+        assertThat(loggingEvent.getFormattedMessage().trim())
+            .contains("/court/SHF/case/1600028974/grouped-offender-matches/4");
+    }
+
+    @Test
+    public void givenUnknownCourt_whenPostOffenderMatches_thenReportErrorToEventBus() {
+
+        GroupedOffenderMatches matches = GroupedOffenderMatches.builder()
+            .matches(Collections.singletonList(OffenderMatch.builder()
+                .matchType(MatchType.ALL_SUPPLIED)
+                .matchIdentifiers(MatchIdentifiers.builder()
+                    .crn("X99999")
+                    .cro("E1324/11")
+                    .pnc("PNC")
+                    .build())
+                .build()))
+            .build();
+
+        restClient.postMatches("XXX", CASE_NO, matches);
+
+        verify(mockAppender, timeout(WEB_CLIENT_TIMEOUT_MS)).doAppend(captorLoggingEvent.capture());
+
+        List<LoggingEvent> events = captorLoggingEvent.getAllValues();
+        LoggingEvent loggingEvent = events.get(0);
+        assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(loggingEvent.getFormattedMessage().trim())
+            .startsWith("Unexpected exception when POST matches for case number '12345' for court 'XXX'");
+    }
+
+    @Test
+    public void whenRestClientThrows500OnPostMatches_ThenFailureEvent() {
+
+        GroupedOffenderMatches matches = GroupedOffenderMatches.builder()
+            .matches(Collections.singletonList(OffenderMatch.builder()
+                .matchType(MatchType.ALL_SUPPLIED)
+                .matchIdentifiers(MatchIdentifiers.builder()
+                    .crn("X99999")
+                    .cro("E1324/11")
+                    .pnc("PNC")
+                    .build())
+                .build()))
+            .build();
+
+        restClient.postMatches("X500", CASE_NO, matches);
+
+        verify(mockAppender, timeout(WEB_CLIENT_TIMEOUT_MS)).doAppend(captorLoggingEvent.capture());
+
+        List<LoggingEvent> events = captorLoggingEvent.getAllValues();
+        LoggingEvent loggingEvent = events.get(0);
+        assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(loggingEvent.getFormattedMessage().trim())
+            .startsWith("Unexpected exception when POST matches for case number '12345' for court 'X500'");
+
+    }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
@@ -203,7 +203,7 @@ public class CourtCaseRestClientIntTest {
 
         GroupedOffenderMatches matches = GroupedOffenderMatches.builder()
             .matches(Collections.singletonList(OffenderMatch.builder()
-                .matchType(MatchType.ALL_SUPPLIED)
+                .matchType(MatchType.NAME_DOB)
                 .matchIdentifiers(MatchIdentifiers.builder()
                     .crn("X99999")
                     .cro("E1324/11")

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchResponseRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchResponseRestClientIntTest.java
@@ -13,8 +13,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.justice.probation.courtcasematcher.event.OffenderSearchFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.event.OffenderSearchValidationFailureEvent;
-import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 
 import java.time.LocalDate;
@@ -52,7 +52,7 @@ public class OffenderSearchResponseRestClientIntTest {
                 .blockOptional();
 
         assertThat(match).isPresent();
-        assertThat(match.get().getMatchedBy()).isEqualTo(MatchType.ALL_SUPPLIED);
+        assertThat(match.get().getMatchedBy()).isEqualTo(OffenderSearchMatchType.ALL_SUPPLIED);
         assertThat(match.get().getMatches().size()).isEqualTo(1);
 
         Offender offender = match.get().getMatches().get(0).getOffender();
@@ -67,7 +67,7 @@ public class OffenderSearchResponseRestClientIntTest {
                 .blockOptional();
 
         assertThat(match).isPresent();
-        assertThat(match.get().getMatchedBy()).isEqualTo(MatchType.ALL_SUPPLIED);
+        assertThat(match.get().getMatchedBy()).isEqualTo(OffenderSearchMatchType.ALL_SUPPLIED);
         assertThat(match.get().getMatches().size()).isEqualTo(2);
 
         Offender offender1 = match.get().getMatches().get(0).getOffender();
@@ -87,7 +87,7 @@ public class OffenderSearchResponseRestClientIntTest {
                 .blockOptional();
 
         assertThat(match).isPresent();
-        assertThat(match.get().getMatchedBy()).isEqualTo(MatchType.NOTHING);
+        assertThat(match.get().getMatchedBy()).isEqualTo(OffenderSearchMatchType.NOTHING);
         assertThat(match.get().getMatches().size()).isEqualTo(0);
     }
 

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -152,7 +152,7 @@ class MatcherServiceTest {
         matcherService.match(incomingCase);
 
         verify(caseMapper).merge(incomingCase, courtCase);
-        verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
+        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class));
         verify(caseMapper, never()).newFromCase(incomingCase);
         verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
         verify(courtCaseRestClient, never()).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
@@ -169,7 +169,7 @@ class MatcherServiceTest {
 
         verify(caseMapper).newFromCase(incomingCase);
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
+        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class));
         verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
         verify(courtCaseRestClient, never()).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
     }
@@ -178,17 +178,16 @@ class MatcherServiceTest {
     void givenIncomingCaseDoesNotMatchExistingCase_andItExactlyMatchesASingleOffender_whenMatchCalled_thenCreateANewRecordWithOffenderData(){
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleExactMatch));
-        when(caseMapper.newFromCaseAndOffender(incomingCase, offender)).thenReturn(courtCase);
+        when(caseMapper.newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class))).thenReturn(courtCase);
         when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
-        verify(caseMapper).newFromCaseAndOffender(incomingCase, offender);
+        verify(caseMapper).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class));
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
         verify(caseMapper, never()).newFromCase(incomingCase);
         verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
         verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verify(courtCaseRestClient).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
         verifyNoMoreInteractions(courtCaseRestClient);
     }
 
@@ -203,12 +202,9 @@ class MatcherServiceTest {
 
         verify(caseMapper).newFromCase(incomingCase);
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
+        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class));
         verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
         verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verify(courtCaseRestClient).postMatches(COURT_CODE, CASE_NO, GroupedOffenderMatches.builder()
-                                                                                            .matches(Arrays.asList(offenderMatch, offenderMatch))
-                                                                                            .build());
         verifyNoMoreInteractions(courtCaseRestClient);
     }
 
@@ -217,14 +213,14 @@ class MatcherServiceTest {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(noMatches));
         when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
+        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
         verify(caseMapper).newFromCase(incomingCase);
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class));
+        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
         verifyNoMoreInteractions(courtCaseRestClient);
     }
 
@@ -239,8 +235,8 @@ class MatcherServiceTest {
 
         verify(caseMapper).newFromCase(incomingCase);
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class));
+        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
         verifyNoMoreInteractions(courtCaseRestClient);
     }
 
@@ -248,7 +244,7 @@ class MatcherServiceTest {
     public void whenMatchesReturned_thenPostMatchesAndLogTheDetails() {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleExactMatch));
-        when(caseMapper.newFromCaseAndOffender(incomingCase, offender)).thenReturn(courtCase);
+        when(caseMapper.newFromCaseAndOffender(eq(incomingCase), eq(offender), any(GroupedOffenderMatches.class))).thenReturn(courtCase);
         when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
@@ -260,7 +256,6 @@ class MatcherServiceTest {
 
         verify(courtCaseRestClient).putCourtCase(COURT_CODE, CASE_NO, courtCase);
         verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
-        verify(courtCaseRestClient).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
         verifyNoMoreInteractions(courtCaseRestClient);
     }
 

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -43,6 +43,7 @@ import uk.gov.justice.probation.courtcasematcher.model.mapper.CaseMapper;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Match;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OtherIds;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 import uk.gov.justice.probation.courtcasematcher.restclient.CourtCaseRestClient;
@@ -83,7 +84,7 @@ class MatcherServiceTest {
             .matches(singletonList(Match.builder()
                     .offender(offender)
                     .build()))
-            .matchedBy(MatchType.ALL_SUPPLIED)
+            .matchedBy(OffenderSearchMatchType.ALL_SUPPLIED)
             .build();
     private final SearchResponse multipleExactMatches = SearchResponse.builder()
             .matches(Arrays.asList(
@@ -93,21 +94,21 @@ class MatcherServiceTest {
                     Match.builder()
                     .offender(offender)
                     .build()))
-            .matchedBy(MatchType.ALL_SUPPLIED)
+            .matchedBy(OffenderSearchMatchType.ALL_SUPPLIED)
             .build();
     private final SearchResponse noMatches = SearchResponse.builder()
-            .matchedBy(MatchType.NOTHING)
+            .matchedBy(OffenderSearchMatchType.NOTHING)
             .matches(Collections.emptyList())
             .build();
     private final SearchResponse singleFuzzyMatch = SearchResponse.builder()
             .matches(singletonList(Match.builder()
                     .offender(offender)
                     .build()))
-            .matchedBy(MatchType.PARTIAL_NAME_DOB_LENIENT)
+            .matchedBy(OffenderSearchMatchType.PARTIAL_NAME_DOB_LENIENT)
             .build();
 
     private final OffenderMatch offenderMatch = OffenderMatch.builder()
-        .matchType(MatchType.ALL_SUPPLIED)
+        .matchType(MatchType.NAME_DOB)
         .confirmed(false)
         .matchIdentifiers(MatchIdentifiers.builder()
             .crn(CRN)

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -1,10 +1,26 @@
 package uk.gov.justice.probation.courtcasematcher.service;
 
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +33,9 @@ import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.MatchIdentifiers;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderMatch;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Block;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
@@ -24,26 +43,17 @@ import uk.gov.justice.probation.courtcasematcher.model.mapper.CaseMapper;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Match;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OtherIds;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 import uk.gov.justice.probation.courtcasematcher.restclient.CourtCaseRestClient;
 import uk.gov.justice.probation.courtcasematcher.restclient.OffenderSearchRestClient;
-
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-import static org.slf4j.LoggerFactory.getLogger;
 
 @ExtendWith(MockitoExtension.class)
 class MatcherServiceTest {
     private static final String COURT_CODE = "SHF";
     private static final String CASE_NO = "1600032952";
     private static final long REST_CLIENT_WAIT_MS = 2000;
+    private static final String CRN = "X123456";
 
     private final LocalDate DEF_DOB = LocalDate.of(2000, 6, 17);
     private final String DEF_NAME = "Arthur MORGAN";
@@ -57,14 +67,20 @@ class MatcherServiceTest {
                             .build())
                     .build())
             .build();
+    private final OtherIds otherIds = OtherIds.builder()
+        .crn(CRN)
+        .cro("CRO")
+        .pnc("PNC")
+        .build();
     private final CourtCase courtCase = CourtCase.builder()
             .caseNo(CASE_NO)
             .courtCode(COURT_CODE)
             .build();
     private final Offender offender = Offender.builder()
+            .otherIds(otherIds)
             .build();
     private final SearchResponse singleExactMatch = SearchResponse.builder()
-            .matches(Collections.singletonList(Match.builder()
+            .matches(singletonList(Match.builder()
                     .offender(offender)
                     .build()))
             .matchedBy(MatchType.ALL_SUPPLIED)
@@ -84,11 +100,25 @@ class MatcherServiceTest {
             .matches(Collections.emptyList())
             .build();
     private final SearchResponse singleFuzzyMatch = SearchResponse.builder()
-            .matches(Collections.singletonList(Match.builder()
+            .matches(singletonList(Match.builder()
                     .offender(offender)
                     .build()))
             .matchedBy(MatchType.PARTIAL_NAME_DOB_LENIENT)
             .build();
+
+    private final OffenderMatch offenderMatch = OffenderMatch.builder()
+        .matchType(MatchType.ALL_SUPPLIED)
+        .confirmed(false)
+        .matchIdentifiers(MatchIdentifiers.builder()
+            .crn(CRN)
+            .cro("CRO")
+            .pnc("PNC")
+            .build())
+        .build();
+
+    private final GroupedOffenderMatches groupedOffenderMatches = GroupedOffenderMatches.builder()
+        .matches(singletonList(offenderMatch))
+        .build();
 
     @Mock
     private CourtCaseRestClient courtCaseRestClient;
@@ -99,8 +129,6 @@ class MatcherServiceTest {
     @Mock
     private Appender<ILoggingEvent> mockAppender;
 
-    private Logger logger;
-
     @Captor
     private ArgumentCaptor<LoggingEvent> captorLoggingEvent;
 
@@ -109,7 +137,7 @@ class MatcherServiceTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        logger = (Logger) getLogger(LoggerFactory.getLogger(MatcherService.class).getName());
+        Logger logger = (Logger) getLogger(LoggerFactory.getLogger(MatcherService.class).getName());
         logger.addAppender(mockAppender);
 
         matcherService = new MatcherService(courtCaseRestClient, offenderSearchRestClient, caseMapper);
@@ -119,14 +147,15 @@ class MatcherServiceTest {
     public void givenIncomingCaseMatchesExisting_whenMatchCalled_thenMergeAndStore() {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.just(courtCase));
         when(caseMapper.merge(incomingCase, courtCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
+        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
         verify(caseMapper).merge(incomingCase, courtCase);
         verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
         verify(caseMapper, never()).newFromCase(incomingCase);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+        verify(courtCaseRestClient, never()).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
     }
 
     @Test
@@ -134,14 +163,15 @@ class MatcherServiceTest {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.empty());
         when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
+        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
         verify(caseMapper).newFromCase(incomingCase);
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
         verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+        verify(courtCaseRestClient, never()).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
     }
 
     @Test
@@ -149,14 +179,17 @@ class MatcherServiceTest {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleExactMatch));
         when(caseMapper.newFromCaseAndOffender(incomingCase, offender)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
+        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
         verify(caseMapper).newFromCaseAndOffender(incomingCase, offender);
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
         verify(caseMapper, never()).newFromCase(incomingCase);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
+        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+        verify(courtCaseRestClient).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
+        verifyNoMoreInteractions(courtCaseRestClient);
     }
 
     @Test
@@ -164,14 +197,19 @@ class MatcherServiceTest {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(multipleExactMatches));
         when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
+        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
         verify(caseMapper).newFromCase(incomingCase);
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
         verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
+        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+        verify(courtCaseRestClient).postMatches(COURT_CODE, CASE_NO, GroupedOffenderMatches.builder()
+                                                                                            .matches(Arrays.asList(offenderMatch, offenderMatch))
+                                                                                            .build());
+        verifyNoMoreInteractions(courtCaseRestClient);
     }
 
     @Test
@@ -187,6 +225,7 @@ class MatcherServiceTest {
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
         verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
         verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verifyNoMoreInteractions(courtCaseRestClient);
     }
 
     @Test
@@ -202,21 +241,27 @@ class MatcherServiceTest {
         verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
         verify(caseMapper, never()).newFromCaseAndOffender(incomingCase, offender);
         verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase));
+        verifyNoMoreInteractions(courtCaseRestClient);
     }
 
     @Test
-    public void whenMatchesReturned_thenLogTheDetails() {
+    public void whenMatchesReturned_thenPostMatchesAndLogTheDetails() {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleExactMatch));
         when(caseMapper.newFromCaseAndOffender(incomingCase, offender)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
+        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
-        LoggingEvent loggingEvent = captureLogEvent();
+        LoggingEvent loggingEvent = captureFirstLogEvent();
         assertThat(loggingEvent.getLevel()).isEqualTo(Level.INFO);
         assertThat(loggingEvent.getFormattedMessage().trim())
                 .contains("Match results for caseNo: 1600032952, courtCode: SHF - matchedBy: ALL_SUPPLIED, matchCount: 1");
+
+        verify(courtCaseRestClient).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+        verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
+        verify(courtCaseRestClient).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
+        verifyNoMoreInteractions(courtCaseRestClient);
     }
 
     @Test
@@ -224,17 +269,18 @@ class MatcherServiceTest {
         when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.empty());
         when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
+        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
         matcherService.match(incomingCase);
 
-        LoggingEvent loggingEvent = captureLogEvent();
+        LoggingEvent loggingEvent = captureFirstLogEvent();
         assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR);
         assertThat(loggingEvent.getFormattedMessage().trim())
                 .contains("Match results for caseNo: 1600032952, courtCode: SHF - Empty response from OffenderSearchRestClient");
+        verifyNoMoreInteractions(courtCaseRestClient);
     }
 
-    private LoggingEvent captureLogEvent() {
+    private LoggingEvent captureFirstLogEvent() {
         verify(mockAppender).doAppend(captorLoggingEvent.capture());
 
         List<LoggingEvent> events = captorLoggingEvent.getAllValues();

--- a/src/test/resources/mocks/mappings/post-matches/POST_match_by_court_and_case_no.json
+++ b/src/test/resources/mocks/mappings/post-matches/POST_match_by_court_and_case_no.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/court/SHF/case/12345/grouped-offender-matches",
+    "bodyPatterns": [
+      {
+        "matches" : ".*X123456.*"
+      }
+    ]
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json",
+      "Location": "/court/SHF/case/1600028974/grouped-offender-matches/4"
+    }
+  }
+}

--- a/src/test/resources/mocks/mappings/post-matches/POST_match_by_unknown_court_404.json
+++ b/src/test/resources/mocks/mappings/post-matches/POST_match_by_unknown_court_404.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/court/XXX/case/12345/grouped-offender-matches",
+    "bodyPatterns": [
+      {
+        "matches" : ".*X99999.*"
+      }
+    ]
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": "{\n  \"status\": 404,\n  \"userMessage\": \"Court XXX not found\",\n  \"developerMessage\": \"Court XXX not found\"\n}"
+  }
+}

--- a/src/test/resources/mocks/mappings/post-matches/POST_match_server_error_500.json
+++ b/src/test/resources/mocks/mappings/post-matches/POST_match_server_error_500.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/court/X500/case/12345/grouped-offender-matches",
+    "bodyPatterns": [
+      {
+        "matches" : ".*X99999.*"
+      }
+    ]
+  },
+  "response": {
+    "status": 500,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
Was not entirely sure where it was best that we added the call to POST  the matches.  As you can see around line 62, it happens when SearchResponse returns and at the moment, we are filtering by MatchType of ALL_SUPPLIED.