### PR TITLE
Log json profile

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,7 +21,7 @@ env:
   JAVA_OPTS: "-Xmx512m"
 
 spring:
-  profile: preprod
+  profile: preprod,instrumented
 
 whitelist:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,7 +21,7 @@ env:
   JAVA_OPTS: "-Xmx512m"
 
 spring:
-  profile: prod
+  profile: prod,instrumented
 
 whitelist:
   office: "217.33.148.210/32"

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -35,21 +35,6 @@
         <appender-ref ref="aiAppender"/>
     </logger>
 
-    <logger name="org.springframework" additivity="false" level="INFO" >
-        <appender-ref ref="consoleAppender"/>
-        <appender-ref ref="aiAppender"/>
-    </logger>
-
-    <logger name="springfox.documentation.spring" additivity="false" level="INFO" >
-        <appender-ref ref="consoleAppender"/>
-        <appender-ref ref="aiAppender"/>
-    </logger>
-
-    <logger name="com.zaxxer.hikari" additivity="false" level="WARN" >
-        <appender-ref ref="consoleAppender"/>
-        <appender-ref ref="aiAppender"/>
-    </logger>
-
     <root level="INFO">
         <appender-ref ref="consoleAppender"/>
         <appender-ref ref="aiAppender"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,22 +7,27 @@
     <springProperty scope="context" name="app" source="spring.application.name"/>
 
     <springProfile name="!instrumented">
+        <appender name="aiAppender" class="ch.qos.logback.core.helpers.NOPAppender"/>
+    </springProfile>
+
+    <springProfile name="instrumented">
+        <appender name="aiAppender" class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender"/>
+    </springProfile>
+
+    <springProfile name="!log-json">
         <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <Pattern>${LOG_PATTERN}</Pattern>
             </layout>
         </appender>
-        <appender name="aiAppender" class="ch.qos.logback.core.helpers.NOPAppender"/>
     </springProfile>
 
-    <springProfile name="instrumented">
+    <springProfile name="log-json">
         <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <includeCallerInfo>true</includeCallerInfo>
             </encoder>
         </appender>
-
-        <appender name="aiAppender" class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender"/>
     </springProfile>
 
     <logger name="uk.gov.justice.probation.courtcasematcher" additivity="false" level="DEBUG">


### PR DESCRIPTION
I've broken the `instrumented` profile into two because the json logging cpability which I was hoping to use isn't yet supported by Kibana in Cloud Platform - though they are looking into it - [see this ticket](https://github.com/ministryofjustice/cloud-platform/issues/2036)

Hopefully this will follow at some point and we can just enabled the `log-json` profile and that will allow us to access fields encoded into the json directly through Kibana e.g. `json.message` or `json.log_level` rather than doing high level searches across the whole `log` field as we have to do now. 