### PR TITLE
Pic 669 duplicates

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessor.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessor.java
@@ -82,8 +82,7 @@ public class MessageProcessor {
     private void process(MessageType messageType) {
         DocumentWrapper documentWrapper = messageType.getMessageBody().getGatewayOperationType().getExternalDocumentRequest().getDocumentWrapper();
 
-        List<Session> sessions = documentWrapper
-            .getDocument()
+        List<Session> sessions = MessageProcessorUtils.getUniqueDocuments(documentWrapper.getDocument())
             .stream()
             .flatMap(document -> document.getData().getJob().getSessions().stream())
             .collect(Collectors.toList());

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorUtils.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorUtils.java
@@ -1,12 +1,17 @@
 package uk.gov.justice.probation.courtcasematcher.messaging;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
+import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Document;
+import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Info;
+import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.InfoSourceDetail;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
 
 @Slf4j
@@ -47,4 +52,49 @@ public final class MessageProcessorUtils {
         }
         return hearingDates;
     }
+
+    /**
+     * Workaround for tactical solution. We receive a document each time a court list is printed for a date.  There should only be one for
+     * a court code / date of hearing. We can find the correct one by looking for the one with the highest sequence number. This sequence
+     * number is found within a string which is "source_file_name".
+     *
+     * @param sourceDocuments
+     *          the source documents sent in the payload
+     * @return
+     *          a de-duplicated list of documents
+     */
+    static List<Document> getUniqueDocuments(List<Document> sourceDocuments) {
+        Set<Info> uniqueInfo = sourceDocuments.stream().map(Document::getInfo).collect(Collectors.toSet());
+        if (sourceDocuments.size() == uniqueInfo.size()) {
+            log.info("No duplicates found for input documents, size {}", sourceDocuments.size());
+            return sourceDocuments;
+        }
+
+        log.debug("Got {} unique info from {} source documents", uniqueInfo.size(), sourceDocuments.size());
+
+        List<Document> result = new ArrayList<>(uniqueInfo.size());
+        uniqueInfo.forEach(info -> {
+            long maxSequence = getMaxSequenceNumber(sourceDocuments, info);
+            log.debug("Max for court {} on {} is {}", info.getCourtHouse(), info.getDateOfHearing(), maxSequence);
+
+            sourceDocuments.stream()
+                .filter(document -> document.getInfo().equals(info) && maxSequence == document.getInfo().getInfoSourceDetail().getSequence())
+                .findFirst()
+                .ifPresentOrElse(result::add,() -> log.error("Could not match for info {} and sequence value {}", info, maxSequence));
+        });
+
+        return result;
+    }
+
+    static long getMaxSequenceNumber(List<Document> documents, Info info) {
+        InfoSourceDetail infoSourceDetail = documents.stream()
+            .map(Document::getInfo)
+            .filter(info::equals)
+            .map(Info::getInfoSourceDetail)
+            .max(Comparator.comparing(InfoSourceDetail::getSequence))
+            .orElse(null);
+
+        return infoSourceDetail != null ? infoSourceDetail.getSequence() : 0;
+    }
+
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Info.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Info.java
@@ -1,28 +1,41 @@
 
 package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode.Exclude;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import uk.gov.justice.probation.courtcasematcher.messaging.SourceFileNameToOuCodeDeserializer;
+import uk.gov.justice.probation.courtcasematcher.messaging.SourceFileNameDeserializer;
 
 @Builder
 @Data
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
-@JsonIgnoreProperties(value = {"contentType", "dateOfHearing", "courtHouse", "area"})
-public class Info
-{
+@JsonIgnoreProperties(value = {"contentType"})
+public class Info {
 
-    @JsonDeserialize(using = SourceFileNameToOuCodeDeserializer.class)
+    @Exclude
+    @JsonDeserialize(using = SourceFileNameDeserializer.class)
     @JacksonXmlProperty(localName = "source_file_name")
-    private final String ouCode;
+    private final InfoSourceDetail infoSourceDetail;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy", lenient = OptBoolean.TRUE)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    private final LocalDate dateOfHearing;
+
+    private final String area;
+
+    private final String courtHouse;
 
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/InfoSourceDetail.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/InfoSourceDetail.java
@@ -1,0 +1,18 @@
+package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@AllArgsConstructor
+@Builder
+@Data
+public class InfoSourceDetail {
+
+    // 160_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY
+
+    private final long sequence;
+
+    private final String ouCode;
+
+}

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
@@ -70,7 +70,7 @@ public class Session {
 
     // This is a temporary measure for tactical solution. ouCode will be available in this object in the longer term.
     public String getCourtCode() {
-        return Optional.ofNullable(courtCode).orElse(job.getDataJob().getDocument().getInfo().getOuCode());
+        return Optional.ofNullable(courtCode).orElse(job.getDataJob().getDocument().getInfo().getInfoSourceDetail().getOuCode());
     }
 
     @JsonBackReference

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,7 @@ GATEWAY_JMS_PASSWORD: jmsuser
 
 court-case-service:
   base-url: http://localhost:8082/
+  disable-authentication: true
 
 offender-search:
   base-url: https://offender-search.test.delius.probation.hmpps.dsd.io

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,7 +19,6 @@ GATEWAY_JMS_PASSWORD: jmsuser
 
 court-case-service:
   base-url: http://localhost:8082/
-  disable-authentication: true
 
 offender-search:
   base-url: https://offender-search.test.delius.probation.hmpps.dsd.io

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParserTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParserTest.java
@@ -102,10 +102,10 @@ public class GatewayMessageParserTest {
 
         assertThat(documents).hasSize(2);
         Document document = documents.stream()
-            .filter(doc -> doc.getInfo().getOuCode().equals("B01CX00"))
+            .filter(doc -> doc.getInfo().getInfoSourceDetail().getOuCode().equals("B01CX00"))
             .findFirst().orElseThrow();
 
-        assertThat(document.getInfo().getOuCode()).isEqualTo("B01CX00");
+        assertThat(document.getInfo().getInfoSourceDetail().getOuCode()).isEqualTo("B01CX00");
         assertThat(document.getData().getJob().getSessions()).hasSize(1);
         checkSession(document.getData().getJob().getSessions().get(0));
     }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorUtilsTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorUtilsTest.java
@@ -171,7 +171,7 @@ class MessageProcessorUtilsTest {
         assertThat(findDocumentSequenceNumber(documents, "B01CX00", july31)).isEqualTo(180);
     }
 
-    @DisplayName("Filters a list of ")
+    @DisplayName("Filters a list of documents where there are no duplicates")
     @Test
     void givenNoDuplicateDocuments_ThenReturnSame() throws IOException {
 

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorUtilsTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorUtilsTest.java
@@ -1,10 +1,20 @@
 package uk.gov.justice.probation.courtcasematcher.messaging;
 
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Block;
@@ -12,6 +22,7 @@ import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.C
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.DataJob;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Document;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Info;
+import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.InfoSourceDetail;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Job;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
 
@@ -20,10 +31,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.probation.courtcasematcher.messaging.MessageProcessorUtils.getCases;
 import static uk.gov.justice.probation.courtcasematcher.messaging.MessageProcessorUtils.getCourtCodes;
 import static uk.gov.justice.probation.courtcasematcher.messaging.MessageProcessorUtils.getHearingDates;
+import static uk.gov.justice.probation.courtcasematcher.messaging.MessageProcessorUtils.getUniqueDocuments;
 
 class MessageProcessorUtilsTest {
 
     private static final int DAY_OFFSET = 3;
+    private static GatewayMessageParser parser;
+
+    @BeforeAll
+    static void beforeAll() {
+        JacksonXmlModule xmlModule = new JacksonXmlModule();
+        xmlModule.setDefaultUseWrapper(false);
+        XmlMapper mapper = new XmlMapper(xmlModule);
+        mapper.registerModule(new JavaTimeModule());
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        parser =  new GatewayMessageParser(mapper, factory.getValidator());
+    }
 
     @DisplayName("Gets distinct set of hearing dates sorted")
     @Test
@@ -128,12 +151,57 @@ class MessageProcessorUtilsTest {
         assertThat(courtCodes).contains("B16BG00", "B01CX00");
     }
 
+    @DisplayName("Filters a list of 23 input documents to the 4 with highest sequence numbers")
+    @Test
+    void givenDuplicateDocuments_ThenDeDuplicate() throws IOException {
+
+        LocalDate july28 = LocalDate.of(2020, Month.JULY, 28);
+        LocalDate july31 = LocalDate.of(2020, Month.JULY, 31);
+
+        List<Document> inputDocuments = getDocumentsFromSample("src/test/resources/messages/gateway-message-duplicates.xml");
+        assertThat(inputDocuments).hasSize(23);
+
+        List<Document> documents = getUniqueDocuments(inputDocuments);
+
+        assertThat(documents).hasSize(4);
+
+        assertThat(findDocumentSequenceNumber(documents, "B16BG00", july28)).isEqualTo(182);
+        assertThat(findDocumentSequenceNumber(documents, "B01CX00", july28)).isEqualTo(179);
+        assertThat(findDocumentSequenceNumber(documents, "B01OB00", july28)).isEqualTo(174);
+        assertThat(findDocumentSequenceNumber(documents, "B01CX00", july31)).isEqualTo(180);
+    }
+
+    @DisplayName("Filters a list of ")
+    @Test
+    void givenNoDuplicateDocuments_ThenReturnSame() throws IOException {
+
+        List<Document> inputDocuments = getDocumentsFromSample("src/test/resources/messages/gateway-message-multi-day.xml");
+
+        List<Document> documents = getUniqueDocuments(inputDocuments);
+
+        assertThat(documents).hasSize(2);
+    }
+
+    private long findDocumentSequenceNumber(List<Document> documents, String courtCode, LocalDate hearingDate) {
+        return documents.stream()
+            .filter(document -> (document.getInfo().getDateOfHearing().equals(hearingDate)
+                                && document.getInfo().getInfoSourceDetail().getOuCode().equals(courtCode)))
+            .findFirst()
+            .map(document -> document.getInfo().getInfoSourceDetail().getSequence())
+            .orElse(-1L);
+    }
+
+    private List<Document> getDocumentsFromSample(String path) throws IOException {
+        String content = Files.readString(Paths.get(path));
+        return parser.parseMessage(content).getMessageBody().getGatewayOperationType().getExternalDocumentRequest().getDocumentWrapper().getDocument();
+    }
+
     private Case buildCase(String caseNo) {
         return Case.builder().caseNo(caseNo).build();
     }
 
     private Job buildJob(String ouCode) {
-        Info info = Info.builder().ouCode(ouCode).build();
+        Info info = Info.builder().infoSourceDetail(InfoSourceDetail.builder().ouCode(ouCode).build()).build();
         Document document = Document.builder().info(info).build();
         DataJob dataJob = DataJob.builder().document(document).build();
         return Job.builder().dataJob(dataJob).build();

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/InfoTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/InfoTest.java
@@ -1,0 +1,23 @@
+package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InfoTest {
+
+    @DisplayName("Ensures that Lombok generated equality ignores the source detail and protects against inadvertent change.")
+    @Test
+    void equalityIgnoresInfo() {
+        LocalDate now = LocalDate.now();
+        InfoSourceDetail identifier1 = InfoSourceDetail.builder().ouCode("B16BG00").sequence(1).build();
+        InfoSourceDetail identifier2 = InfoSourceDetail.builder().ouCode("B16BG00").sequence(2).build();
+
+        Info info1 = Info.builder().courtHouse("Beverley").dateOfHearing(now).infoSourceDetail(identifier1).build();
+        Info info2 = Info.builder().courtHouse("Beverley").dateOfHearing(now).infoSourceDetail(identifier2).build();
+        assertThat(info1).isEqualTo(info2);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
@@ -24,6 +24,7 @@ import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.C
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.DataJob;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Document;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Info;
+import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.InfoSourceDetail;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Job;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
@@ -60,7 +61,7 @@ class CaseMapperTest {
     @BeforeEach
     void beforeEach() {
 
-        Info info = Info.builder().ouCode(COURT_CODE).build();
+        Info info = Info.builder().infoSourceDetail(InfoSourceDetail.builder().ouCode(COURT_CODE).build()).build();
         Document document = Document.builder().info(info).build();
         DataJob dataJob = DataJob.builder().document(document).build();
         Job job = Job.builder().dataJob(dataJob).build();

--- a/src/test/resources/messages/gateway-message-duplicates.xml
+++ b/src/test/resources/messages/gateway-message-duplicates.xml
@@ -1,0 +1,2524 @@
+<ns8:CSCI_Message_Type xmlns:ns6="http://www.justice.gov.uk/magistrates/cp/CSCI_Body" xmlns:ns5="http://www.justice.gov.uk/magistrates/cp/GatewayMessageSchema" xmlns:ns8="http://www.justice.gov.uk/magistrates/cp/CSCI" xmlns:ns7="http://www.justice.gov.uk/magistrates/generic/CSCI_Status" xmlns:ns2="http://www.justice.gov.uk/magistrates/generic/CSCI_Header" xmlns:ns4="http://www.justice.gov.uk/magistrates/external/ExternalDocumentRequest">
+    <ns2:MessageHeader>
+        <MessageID>
+            <UUID>ca4c6061-a8a9-4206-b85c-1fa287aad93a</UUID>
+            <RelatesTo></RelatesTo>
+        </MessageID>
+        <TimeStamp>2020-07-28T12:40:49.906Z</TimeStamp>
+        <MessageType>externalDocument</MessageType>
+        <From>CP_NPS_ML</From>
+        <To>CP_NPS</To>
+    </ns2:MessageHeader>
+    <ns6:MessageBody>
+        <ns5:GatewayOperationType>
+            <ns4:ExternalDocumentRequest>
+                <documents>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>160_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728781</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980978</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001784</c_id>
+                                                        <h_id>1108350</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006126</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D CG DAVIES</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1988</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Wigan</line2>
+                                                            <pcode>WN2 8JJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004131</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at NewTown stole socks, of a value unknown, belonging to Test PeRson.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004132</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted John thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001785</c_id>
+                                                        <h_id>1108351</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006134</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E CG ELLIS</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1955</def_dob>
+                                                        <def_age>64</def_age>
+                                                        <def_addr>
+                                                            <line1>14 High Street</line1>
+                                                            <line2>Neath</line2>
+                                                            <pcode>SA10 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004133</co_id>
+                                                                <code>FO91001</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw a missile onto a football playing area - Football (Offences) Act 1991</title>
+                                                                <sum>On 22/07/2020 at Vetch Field at a designated football match held at Swansea, without lawful authority or lawful excuse, threw bottle at or towards the playing area.</sum>
+                                                                <as>Contrary to Sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                                <sof>.</sof>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001786</c_id>
+                                                        <h_id>1108352</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006142</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case F CG FOOT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Lydney</line2>
+                                                            <pcode>GL15 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004134</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Newtown without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>161_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728781</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980978</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001784</c_id>
+                                                        <h_id>1108350</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006126</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D CG DAVIES</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1988</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Wigan</line2>
+                                                            <pcode>WN2 8JJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004131</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at NewTown stole socks, of a value unknown, belonging to Test PeRson.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004132</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted John thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001785</c_id>
+                                                        <h_id>1108351</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006134</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E CG ELLIS</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1955</def_dob>
+                                                        <def_age>64</def_age>
+                                                        <def_addr>
+                                                            <line1>14 High Street</line1>
+                                                            <line2>Neath</line2>
+                                                            <pcode>SA10 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004133</co_id>
+                                                                <code>FO91001</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw a missile onto a football playing area - Football (Offences) Act 1991</title>
+                                                                <sum>On 22/07/2020 at Vetch Field at a designated football match held at Swansea, without lawful authority or lawful excuse, threw bottle at or towards the playing area.</sum>
+                                                                <as>Contrary to Sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                                <sof>.</sof>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001786</c_id>
+                                                        <h_id>1108352</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006142</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case F CG FOOT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Lydney</line2>
+                                                            <pcode>GL15 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004134</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Newtown without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>162_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728780</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980977</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001826</c_id>
+                                                        <h_id>1108392</h_id>
+                                                        <caseno>2000006436</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN0000999</urn>
+                                                        <def_name>Mr NPS Case N CG NAIL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1991</def_dob>
+                                                        <def_age>28</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Carver Place</line1>
+                                                            <line2>Hull</line2>
+                                                            <pcode>HU1 9LL</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004198</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M CG Mulloch. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>163_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728780</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980977</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001826</c_id>
+                                                        <h_id>1108392</h_id>
+                                                        <caseno>2000006436</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN0000999</urn>
+                                                        <def_name>Mr NPS Case N CG NAIL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1991</def_dob>
+                                                        <def_age>28</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Carver Place</line1>
+                                                            <line2>Hull</line2>
+                                                            <pcode>HU1 9LL</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004198</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M CG Mulloch. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>West London</courtHouse>
+                            <area>01</area>
+                            <source_file_name>164_28072020_2578_B01OB00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>758023</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>West London</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980412</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001800</c_id>
+                                                        <h_id>1108366</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006290</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D WL DEE</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>04/06/1978</def_dob>
+                                                        <def_age>42</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Truro</line2>
+                                                            <pcode>TR2 8KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004154</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at Yate stole socks, of a value unknown, belonging to Andy Ant.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004155</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted Jack Jason thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001801</c_id>
+                                                        <h_id>1108367</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006304</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E WL EALHAM</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>N</def_sex>
+                                                        <def_dob>11/11/1963</def_dob>
+                                                        <def_age>56</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Jarrow</line2>
+                                                            <pcode>NE36 J</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004156</co_id>
+                                                                <code>FO91005</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw missile at spectators area</title>
+                                                                <sum>On 22/07/2020 at Swansea, at a designated football match held at Vetch Field, without lawful authority or lawful excuse, threw stick, at or towards an area in which spectators or other persons were or may have been present.</sum>
+                                                                <as>Contrary to sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001802</c_id>
+                                                        <h_id>1108368</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006312</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr Case NPS F WL FROGITT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1959</def_dob>
+                                                        <def_age>60</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>Rye</line2>
+                                                            <pcode>TN25 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004157</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Usk without lawful excuse, destroyed test of a value unknown belonging to John Jay intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>West London</courtHouse>
+                            <area>01</area>
+                            <source_file_name>165_28072020_2578_B01OB00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>758022</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>West London</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980411</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001824</c_id>
+                                                        <h_id>1108390</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006401</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN000888</urn>
+                                                        <def_name>Mr NPS Case N WL NUTTALL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>04/06/1988</def_dob>
+                                                        <def_age>32</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>York</line2>
+                                                            <pcode>YO12 8JL</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004195</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M WL Mellor. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>166_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728780</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980977</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001826</c_id>
+                                                        <h_id>1108392</h_id>
+                                                        <caseno>2000006436</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN0000999</urn>
+                                                        <def_name>Mr NPS Case N CG NAIL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1991</def_dob>
+                                                        <def_age>28</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Carver Place</line1>
+                                                            <line2>Hull</line2>
+                                                            <pcode>HU1 9LL</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004198</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M CG Mulloch. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>167_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728781</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980978</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001784</c_id>
+                                                        <h_id>1108350</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006126</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D CG DAVIES</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1988</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Wigan</line2>
+                                                            <pcode>WN2 8JJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004131</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at NewTown stole socks, of a value unknown, belonging to Test PeRson.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004132</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted John thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001785</c_id>
+                                                        <h_id>1108351</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006134</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E CG ELLIS</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1955</def_dob>
+                                                        <def_age>64</def_age>
+                                                        <def_addr>
+                                                            <line1>14 High Street</line1>
+                                                            <line2>Neath</line2>
+                                                            <pcode>SA10 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004133</co_id>
+                                                                <code>FO91001</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw a missile onto a football playing area - Football (Offences) Act 1991</title>
+                                                                <sum>On 22/07/2020 at Vetch Field at a designated football match held at Swansea, without lawful authority or lawful excuse, threw bottle at or towards the playing area.</sum>
+                                                                <as>Contrary to Sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                                <sof>.</sof>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001786</c_id>
+                                                        <h_id>1108352</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006142</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case F CG FOOT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Lydney</line2>
+                                                            <pcode>GL15 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004134</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Newtown without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>168_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728781</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980978</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001784</c_id>
+                                                        <h_id>1108350</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006126</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D CG DAVIES</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1988</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Wigan</line2>
+                                                            <pcode>WN2 8JJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004131</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at NewTown stole socks, of a value unknown, belonging to Test PeRson.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004132</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted John thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001785</c_id>
+                                                        <h_id>1108351</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006134</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E CG ELLIS</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1955</def_dob>
+                                                        <def_age>64</def_age>
+                                                        <def_addr>
+                                                            <line1>14 High Street</line1>
+                                                            <line2>Neath</line2>
+                                                            <pcode>SA10 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004133</co_id>
+                                                                <code>FO91001</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw a missile onto a football playing area - Football (Offences) Act 1991</title>
+                                                                <sum>On 22/07/2020 at Vetch Field at a designated football match held at Swansea, without lawful authority or lawful excuse, threw bottle at or towards the playing area.</sum>
+                                                                <as>Contrary to Sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                                <sof>.</sof>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001786</c_id>
+                                                        <h_id>1108352</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006142</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case F CG FOOT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Lydney</line2>
+                                                            <pcode>GL15 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004134</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Newtown without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>West London</courtHouse>
+                            <area>01</area>
+                            <source_file_name>169_28072020_2578_B01OB00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>758022</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>West London</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980411</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001824</c_id>
+                                                        <h_id>1108390</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006401</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN000888</urn>
+                                                        <def_name>Mr NPSCaseNWL Fnametwo NUTTALL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>04/06/1988</def_dob>
+                                                        <def_age>32</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>York</line2>
+                                                            <pcode>YO12 8JL</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004195</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M WL Mellor. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>West London</courtHouse>
+                            <area>01</area>
+                            <source_file_name>170_28072020_2578_B01OB00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>758023</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>West London</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980412</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001800</c_id>
+                                                        <h_id>1108366</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006290</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D WL DEE</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>04/06/1978</def_dob>
+                                                        <def_age>42</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Truro</line2>
+                                                            <pcode>TR2 8KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004154</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at Yate stole socks, of a value unknown, belonging to Andy Ant.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004155</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted Jack Jason thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001801</c_id>
+                                                        <h_id>1108367</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006304</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E WL EALHAM</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>N</def_sex>
+                                                        <def_dob>11/11/1963</def_dob>
+                                                        <def_age>56</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Jarrow</line2>
+                                                            <pcode>NE36 J</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004156</co_id>
+                                                                <code>FO91005</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw missile at spectators area</title>
+                                                                <sum>On 22/07/2020 at Swansea, at a designated football match held at Vetch Field, without lawful authority or lawful excuse, threw stick, at or towards an area in which spectators or other persons were or may have been present.</sum>
+                                                                <as>Contrary to sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001802</c_id>
+                                                        <h_id>1108368</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006312</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr Case NPS F WL FROGITT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1959</def_dob>
+                                                        <def_age>60</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>Rye</line2>
+                                                            <pcode>TN25 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004157</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Usk without lawful excuse, destroyed test of a value unknown belonging to John Jay intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Beverley</courtHouse>
+                            <area>12</area>
+                            <source_file_name>171_28072020_1942_B16BG00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>humber.usertwo</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>759974</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>East Yorkshire Magistrates' Court</lja>
+                                        <cmu>Humberside Management Unit 1</cmu>
+                                        <panel>Adult - Civil</panel>
+                                        <court>Beverley</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:00</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>983551</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:00</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001822</c_id>
+                                                        <h_id>1108388</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003596</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case N Hu NILL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/11/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>111 Main Street</line1>
+                                                            <line2>Tintern</line2>
+                                                            <pcode>NP23 9KL</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004192</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M HU Manning. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Beverley</courtHouse>
+                            <area>12</area>
+                            <source_file_name>172_28072020_1942_B16BG00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>humber.usertwo</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>759975</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>East Yorkshire Magistrates' Court</lja>
+                                        <cmu>Humberside Management Unit 1</cmu>
+                                        <panel>Adult - Civil</panel>
+                                        <court>Beverley</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:00</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>983552</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:00</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001812</c_id>
+                                                        <h_id>1108378</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003480</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D HU DUMAR</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>03/06/1971</def_dob>
+                                                        <def_age>49</def_age>
+                                                        <def_addr>
+                                                            <line1>22 Station Road</line1>
+                                                            <line2>Hereford</line2>
+                                                            <pcode>HR2 9KJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004173</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004174</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Margate assaulted TestPerson thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001813</c_id>
+                                                        <h_id>1108379</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003499</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E HU EADIE</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>08/07/1945</def_dob>
+                                                        <def_age>75</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Station Road</line1>
+                                                            <line2>Truro</line2>
+                                                            <pcode>TR2 9LP</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004175</co_id>
+                                                                <code>FO91005</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw missile at spectators area</title>
+                                                                <sum>On 22/07/2020 at Swansea, at a designated football match held at Vetch Field, without lawful authority or lawful excuse, threw table, at or towards an area in which spectators or other persons were or may have been present.</sum>
+                                                                <as>Contrary to sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001814</c_id>
+                                                        <h_id>1108380</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003502</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case F HU FRY</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>01/06/1989</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>Beverley</line2>
+                                                            <pcode>HU11 8KL</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004177</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Usk without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>West London</courtHouse>
+                            <area>01</area>
+                            <source_file_name>173_28072020_2578_B01OB00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>758022</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>West London</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980411</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001824</c_id>
+                                                        <h_id>1108390</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006401</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN0000820</urn>
+                                                        <def_name>Mr NPSCaseNWL Fnametwo NUTTALL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>04/06/1988</def_dob>
+                                                        <def_age>32</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>York</line2>
+                                                            <pcode>YO12 8JL</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004195</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M WL Mellor. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>West London</courtHouse>
+                            <area>01</area>
+                            <source_file_name>174_28072020_2578_B01OB00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>758023</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>West London</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980412</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001800</c_id>
+                                                        <h_id>1108366</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006290</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseDWL DEE</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>04/06/1978</def_dob>
+                                                        <def_age>42</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Truro</line2>
+                                                            <pcode>TR2 8KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004154</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at Yate stole socks, of a value unknown, belonging to Andy Ant.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004155</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted Jack Jason thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001801</c_id>
+                                                        <h_id>1108367</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006304</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseEWL EALHAM</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>N</def_sex>
+                                                        <def_dob>11/11/1963</def_dob>
+                                                        <def_age>56</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Jarrow</line2>
+                                                            <pcode>NE36 J</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004156</co_id>
+                                                                <code>FO91005</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw missile at spectators area</title>
+                                                                <sum>On 22/07/2020 at Swansea, at a designated football match held at Vetch Field, without lawful authority or lawful excuse, threw stick, at or towards an area in which spectators or other persons were or may have been present.</sum>
+                                                                <as>Contrary to sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001802</c_id>
+                                                        <h_id>1108368</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006312</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr CaseNPSFWL FROGITT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1959</def_dob>
+                                                        <def_age>60</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>Rye</line2>
+                                                            <pcode>TN25 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004157</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Usk without lawful excuse, destroyed test of a value unknown belonging to John Jay intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Beverley</courtHouse>
+                            <area>12</area>
+                            <source_file_name>175_28072020_1942_B16BG00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>humber.usersix</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>759975</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>East Yorkshire Magistrates' Court</lja>
+                                        <cmu>Humberside Management Unit 1</cmu>
+                                        <panel>Adult - Civil</panel>
+                                        <court>Beverley</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:00</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>983552</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:00</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001812</c_id>
+                                                        <h_id>1108378</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003480</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case D HU DUMAR</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>03/06/1971</def_dob>
+                                                        <def_age>49</def_age>
+                                                        <def_addr>
+                                                            <line1>22 Station Road</line1>
+                                                            <line2>Hereford</line2>
+                                                            <pcode>HR2 9KJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004173</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004174</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Margate assaulted TestPerson thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001813</c_id>
+                                                        <h_id>1108379</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003499</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case E HU EADIE</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>08/07/1945</def_dob>
+                                                        <def_age>75</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Station Road</line1>
+                                                            <line2>Truro</line2>
+                                                            <pcode>TR2 9LP</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004175</co_id>
+                                                                <code>FO91005</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw missile at spectators area</title>
+                                                                <sum>On 22/07/2020 at Swansea, at a designated football match held at Vetch Field, without lawful authority or lawful excuse, threw table, at or towards an area in which spectators or other persons were or may have been present.</sum>
+                                                                <as>Contrary to sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001814</c_id>
+                                                        <h_id>1108380</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003502</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case F HU FRY</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>01/06/1989</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>Beverley</line2>
+                                                            <pcode>HU11 8KL</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004177</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Usk without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Beverley</courtHouse>
+                            <area>12</area>
+                            <source_file_name>176_28072020_1942_B16BG00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>humber.usersix</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>759974</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>East Yorkshire Magistrates' Court</lja>
+                                        <cmu>Humberside Management Unit 1</cmu>
+                                        <panel>Adult - Civil</panel>
+                                        <court>Beverley</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:00</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>983551</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:00</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001822</c_id>
+                                                        <h_id>1108388</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003596</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case N Hu NILL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/11/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>111 Main Street</line1>
+                                                            <line2>Tintern</line2>
+                                                            <pcode>NP23 9KL</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004192</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M HU Manning. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Beverley</courtHouse>
+                            <area>12</area>
+                            <source_file_name>177_28072020_1942_B16BG00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>24/07/2020</printdate>
+                                <username>humber.usersix</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>759974</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>East Yorkshire Magistrates' Court</lja>
+                                        <cmu>Humberside Management Unit 1</cmu>
+                                        <panel>Adult - Civil</panel>
+                                        <court>Beverley</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:00</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>983551</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:00</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001822</c_id>
+                                                        <h_id>1108388</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003596</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPS Case N Hu NILL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/11/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>111 Main Street</line1>
+                                                            <line2>Tintern</line2>
+                                                            <pcode>NP23 9KL</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004192</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M HU Manning. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>178_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728780</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980977</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001826</c_id>
+                                                        <h_id>1108392</h_id>
+                                                        <caseno>2000006436</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN0000920</urn>
+                                                        <def_name>Mr NPSCaseNCG NAIL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1991</def_dob>
+                                                        <def_age>28</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Carver Place</line1>
+                                                            <line2>Hull</line2>
+                                                            <pcode>HU1 9LL</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004198</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M CG Mulloch. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>179_28072020_2578_B01CX00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728781</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>980978</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001784</c_id>
+                                                        <h_id>1108350</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006126</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseDCG DAVIES</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1988</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Wigan</line2>
+                                                            <pcode>WN2 8JJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004131</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at NewTown stole socks, of a value unknown, belonging to Test PeRson.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004132</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Newtown assaulted John thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001785</c_id>
+                                                        <h_id>1108351</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006134</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseECG ELLIS</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/12/1955</def_dob>
+                                                        <def_age>64</def_age>
+                                                        <def_addr>
+                                                            <line1>14 High Street</line1>
+                                                            <line2>Neath</line2>
+                                                            <pcode>SA10 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004133</co_id>
+                                                                <code>FO91001</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw a missile onto a football playing area - Football (Offences) Act 1991</title>
+                                                                <sum>On 22/07/2020 at Vetch Field at a designated football match held at Swansea, without lawful authority or lawful excuse, threw bottle at or towards the playing area.</sum>
+                                                                <as>Contrary to Sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                                <sof>.</sof>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001786</c_id>
+                                                        <h_id>1108352</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000006142</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseFCG FOOT</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/08/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>11 High Street</line1>
+                                                            <line2>Lydney</line2>
+                                                            <pcode>GL15 9KK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004134</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Newtown without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>31/07/2020</dateOfHearing>
+                            <courtHouse>Camberwell Green</courtHouse>
+                            <area>01</area>
+                            <source_file_name>180_31072020_2578_B01CX00_ADULT_COURT_LIST_FUTURE</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>gl.userseven</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>728847</s_id>
+                                        <doh>31/07/2020</doh>
+                                        <lja>North West London Magistrates' Court</lja>
+                                        <cmu>Gl Management Unit 1</cmu>
+                                        <panel>Adult Panel</panel>
+                                        <court>Camberwell Green</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:30</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>981044</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:30</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1002771</c_id>
+                                                        <h_id>1109337</h_id>
+                                                        <caseno>2000006444</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr michael peter OLIVER</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/02/1976</def_dob>
+                                                        <def_age>44</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>Ely</line2>
+                                                            <pcode>CB11 9KJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1005118</co_id>
+                                                                <code>TH68050</code>
+                                                                <maxpen>S: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Take a motor vehicle without the owners consent</title>
+                                                                <sum>On 22/07/2020 at Ely, without the consent of the owner, or other lawful authority, took a conveyance, namely Mazda OY66RRR for the use of yourself or another.</sum>
+                                                                <as>Contrary to section 12(1) of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1002772</c_id>
+                                                        <h_id>1109338</h_id>
+                                                        <caseno>2000006452</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr peter philip paul POWELL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>12/11/1988</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Station Road</line1>
+                                                            <line2>Usk</line2>
+                                                            <pcode>NP11 8JK</pcode>
+                                                        </def_addr>
+                                                        <inf>POL01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1005119</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Usk assaulted Barrie Bould thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Beverley</courtHouse>
+                            <area>12</area>
+                            <source_file_name>181_28072020_1942_B16BG00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>humber.usersix</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>759974</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>East Yorkshire Magistrates' Court</lja>
+                                        <cmu>Humberside Management Unit 1</cmu>
+                                        <panel>Adult - Civil</panel>
+                                        <court>Beverley</court>
+                                        <room>8</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:00</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>983551</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:00</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001822</c_id>
+                                                        <h_id>1108388</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003596</caseno>
+                                                        <type>C</type>
+                                                        <urn>06NN0000720</urn>
+                                                        <def_name>Mr NPSCaseNHu NILL</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>11/11/1976</def_dob>
+                                                        <def_age>43</def_age>
+                                                        <def_addr>
+                                                            <line1>111 Main Street</line1>
+                                                            <line2>Tintern</line2>
+                                                            <pcode>NP23 9KL</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004192</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>Concerned with NPS Case M HU Manning. On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                    <document>
+                        <ns4:info>
+                            <contentType>StandardCourtList</contentType>
+                            <dateOfHearing>28/07/2020</dateOfHearing>
+                            <courtHouse>Beverley</courtHouse>
+                            <area>12</area>
+                            <source_file_name>182_28072020_1942_B16BG00_ADULT_COURT_LIST_DAILY</source_file_name>
+                        </ns4:info>
+                        <data>
+                            <job>
+                                <printdate>27/07/2020</printdate>
+                                <username>humber.usersix</username>
+                                <late>N</late>
+                                <adbox>N</adbox>
+                                <means>N</means>
+                                <sessions>
+                                    <session>
+                                        <s_id>759975</s_id>
+                                        <doh>28/07/2020</doh>
+                                        <lja>East Yorkshire Magistrates' Court</lja>
+                                        <cmu>Humberside Management Unit 1</cmu>
+                                        <panel>Adult - Civil</panel>
+                                        <court>Beverley</court>
+                                        <room>9</room>
+                                        <sstart>09:00</sstart>
+                                        <send>13:00</send>
+                                        <blocks>
+                                            <block>
+                                                <sb_id>983552</sb_id>
+                                                <bstart>09:00</bstart>
+                                                <bend>13:00</bend>
+                                                <desc>First Hearings Slot</desc>
+                                                <cases>
+                                                    <case>
+                                                        <c_id>1001812</c_id>
+                                                        <h_id>1108378</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003480</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseDHU DUMAR</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>03/06/1971</def_dob>
+                                                        <def_age>49</def_age>
+                                                        <def_addr>
+                                                            <line1>22 Station Road</line1>
+                                                            <line2>Hereford</line2>
+                                                            <pcode>HR2 9KJ</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>1</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004173</co_id>
+                                                                <code>TH68001</code>
+                                                                <maxpen>S:6Months &amp;/or  LE pp</maxpen>
+                                                                <title>Theft from the person of another</title>
+                                                                <sum>On 22/07/2020 at Usk stole shoes, of a value unknown, belonging to Test Person.</sum>
+                                                                <as>Contrary to section 1(1) and 7 of the Theft Act 1968.</as>
+                                                            </offence>
+                                                            <offence>
+                                                                <oseq>2</oseq>
+                                                                <co_id>1004174</co_id>
+                                                                <code>CD98073</code>
+                                                                <maxpen>EW: 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Racially / religiously aggravated assault occasioning actual bodily harm</title>
+                                                                <sum>On 22/07/2020 at Margate assaulted TestPerson thereby occasioning him actual bodily harm and the offence was racially aggravated within the terms of section 28 of the Crime and Disorder Act 1998.</sum>
+                                                                <as>Contrary to section 29(1)(b) and (2) of the Crime and Disorder Act 1998.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001813</c_id>
+                                                        <h_id>1108379</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003499</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseEHU EADIE</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>08/07/1945</def_dob>
+                                                        <def_age>75</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Station Road</line1>
+                                                            <line2>Truro</line2>
+                                                            <pcode>TR2 9LP</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>2</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004175</co_id>
+                                                                <code>FO91005</code>
+                                                                <maxpen>S: L3</maxpen>
+                                                                <title>Throw missile at spectators area</title>
+                                                                <sum>On 22/07/2020 at Swansea, at a designated football match held at Vetch Field, without lawful authority or lawful excuse, threw table, at or towards an area in which spectators or other persons were or may have been present.</sum>
+                                                                <as>Contrary to sections 2 and 5 of the Football (Offences) Act 1991.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                    <case>
+                                                        <c_id>1001814</c_id>
+                                                        <h_id>1108380</h_id>
+                                                        <valid>Y</valid>
+                                                        <caseno>2000003502</caseno>
+                                                        <type>C</type>
+                                                        <def_name>Mr NPSCaseFHU FRY</def_name>
+                                                        <def_type>P</def_type>
+                                                        <def_sex>M</def_sex>
+                                                        <def_dob>01/06/1989</def_dob>
+                                                        <def_age>31</def_age>
+                                                        <def_addr>
+                                                            <line1>11 Main Street</line1>
+                                                            <line2>Beverley</line2>
+                                                            <pcode>HU11 8KL</pcode>
+                                                        </def_addr>
+                                                        <inf>POLH01</inf>
+                                                        <cseq>3</cseq>
+                                                        <listno>1st</listno>
+                                                        <offences>
+                                                            <offence>
+                                                                <oseq>1</oseq>
+                                                                <co_id>1004177</co_id>
+                                                                <code>CD71040</code>
+                                                                <maxpen>EW: &lt;£5,000 3M &amp;/or L4; &gt;£5,000 6M &amp;/or Ultd Fine</maxpen>
+                                                                <title>Destroy / damage property of a value unknown</title>
+                                                                <sum>On 22/07/2020 at Usk without lawful excuse, destroyed test of a value unknown belonging to Test Person intending to destroy or damage such property or being reckless as to whether such property would be destroyed or damaged.</sum>
+                                                                <as>Contrary to section 1(1) and 4 of the Criminal Damage Act 1971.</as>
+                                                            </offence>
+                                                        </offences>
+                                                    </case>
+                                                </cases>
+                                            </block>
+                                        </blocks>
+                                    </session>
+                                </sessions>
+                            </job>
+                        </data>
+                        <jsonData></jsonData>
+                    </document>
+                </documents>
+            </ns4:ExternalDocumentRequest>
+        </ns5:GatewayOperationType>
+    </ns6:MessageBody>
+    <ns7:MessageStatus>
+        <status></status>
+        <code></code>
+        <reason></reason>
+        <detail></detail>
+    </ns7:MessageStatus>
+</ns8:CSCI_Message_Type>


### PR DESCRIPTION
Rather than one document (case list for a date in a court), we end up getting a document for each time the case list gets printed. This was realised in tests, where we got 23 documents where there should only have been 4. Fixed by adding (yet) another method to the "MessageProcessorUtils". This should not happen in the strategic solution.