### PR TITLE
Pic 686 match on court code

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
@@ -67,13 +67,13 @@ public class Session {
     @NotEmpty
     private final List<@Valid Block> blocks;
 
+    @JsonBackReference
+    private final Job job;
+
     // This is a temporary measure for tactical solution. ouCode will be available in this object in the longer term.
     public String getCourtCode() {
         return courtCode != null ? courtCode : job.getDataJob().getDocument().getInfo().getInfoSourceDetail().getOuCode();
     }
-
-    @JsonBackReference
-    private final Job job;
 
     public LocalDateTime getSessionStartTime() {
         //noinspection ConstantConditions - analysis says these fields may be null but annotations / validation prevents that

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -70,7 +69,7 @@ public class Session {
 
     // This is a temporary measure for tactical solution. ouCode will be available in this object in the longer term.
     public String getCourtCode() {
-        return Optional.ofNullable(courtCode).orElse(job.getDataJob().getDocument().getInfo().getInfoSourceDetail().getOuCode());
+        return courtCode != null ? courtCode : job.getDataJob().getDocument().getInfo().getInfoSourceDetail().getOuCode();
     }
 
     @JsonBackReference

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
@@ -38,7 +38,7 @@ public class MatcherService {
     private final CaseMapper caseMapper;
 
     public void match(Case incomingCase) {
-        restClient.getCourtCase(incomingCase.getBlock().getSession().getCourtName(), incomingCase.getCaseNo())
+        restClient.getCourtCase(incomingCase.getBlock().getSession().getCourtCode(), incomingCase.getCaseNo())
                 .map(existing -> caseMapper.merge(incomingCase, existing))
                 .switchIfEmpty(Mono.defer(() -> newMatchedCaseOf(incomingCase)))
                 .switchIfEmpty(Mono.defer(() -> Mono.just(caseMapper.newFromCase(incomingCase))))
@@ -47,7 +47,7 @@ public class MatcherService {
     }
 
     private Mono<CourtCase> newMatchedCaseOf(Case incomingCase) {
-        final String courtCode = incomingCase.getBlock().getSession().getCourtName();
+        final String courtCode = incomingCase.getBlock().getSession().getCourtCode();
         final String caseNo = incomingCase.getCaseNo();
         return offenderSearchRestClient.search(incomingCase.getDef_name(), incomingCase.getDef_dob())
                 .map(searchResponse -> {
@@ -68,7 +68,7 @@ public class MatcherService {
                 .doOnSuccess((data) -> {
                     if (data == null) {
                         log.error(String.format("Match results for caseNo: %s, courtCode: %s - Empty response from OffenderSearchRestClient",
-                            incomingCase.getCaseNo(), incomingCase.getBlock().getSession().getCourtName()));
+                            incomingCase.getCaseNo(), incomingCase.getBlock().getSession().getCourtCode()));
                     }
                 });
     }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/SessionTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/SessionTest.java
@@ -1,0 +1,41 @@
+package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SessionTest {
+
+    @Test
+    void whenOuCodeNotSession_thenReturnFromParentInfo() {
+        Info info = Info.builder().infoSourceDetail(InfoSourceDetail.builder().ouCode("B10JQ00").build()).build();
+        Document document = Document.builder().info(info).build();
+        DataJob dataJob = DataJob.builder().document(document).build();
+        Job job = Job.builder().dataJob(dataJob).build();
+        Session session = Session.builder().job(job).build();
+
+        assertThat(session.getCourtCode()).isEqualTo("B10JQ00");
+    }
+
+    @Test
+    void whenOuCodeIsInSession_thenReturn() {
+        Session session = Session.builder().courtCode("B10JQ00").build();
+
+        assertThat(session.getCourtCode()).isEqualTo("B10JQ00");
+    }
+
+    @Test
+    void getSessionStartTime() {
+        LocalDate dateOfHearing = LocalDate.of(2020, Month.JULY, 19);
+        Session session = Session.builder()
+            .dateOfHearing(dateOfHearing)
+            .start(LocalTime.NOON)
+            .build();
+
+        assertThat(session.getSessionStartTime()).isEqualTo(LocalDateTime.of(2020, Month.JULY, 19, 12, 0, 0));
+    }
+}

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -58,16 +58,12 @@ class MatcherServiceTest {
 
     private final LocalDate DEF_DOB = LocalDate.of(2000, 6, 17);
     private final String DEF_NAME = "Arthur MORGAN";
-    private final Case incomingCase = Case.builder()
-            .caseNo(CASE_NO)
-            .def_dob(DEF_DOB)
-            .def_name(DEF_NAME)
-            .block(Block.builder()
-                    .session(Session.builder()
-                            .courtName(COURT_CODE)
-                            .build())
-                    .build())
-            .build();
+
+    @Mock
+    private Session session;
+
+    private Case incomingCase;
+
     private final OtherIds otherIds = OtherIds.builder()
         .crn(CRN)
         .cro("CRO")
@@ -140,6 +136,17 @@ class MatcherServiceTest {
         MockitoAnnotations.initMocks(this);
         Logger logger = (Logger) getLogger(LoggerFactory.getLogger(MatcherService.class).getName());
         logger.addAppender(mockAppender);
+
+        incomingCase = Case.builder()
+            .caseNo(CASE_NO)
+            .def_dob(DEF_DOB)
+            .def_name(DEF_NAME)
+            .block(Block.builder()
+                .session(session)
+                .build())
+            .build();
+
+        when(session.getCourtCode()).thenReturn(COURT_CODE);
 
         matcherService = new MatcherService(courtCaseRestClient, offenderSearchRestClient, caseMapper);
     }


### PR DESCRIPTION
We were matching against the court name when calling court case service - so using "Newcastle Magistrate's Court" instead of "B10JQ00" for example