### PR TITLE
✨ Relax validation. No longer try to enforce what is in the XSD, but …

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParser.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParser.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcasematcher.messaging;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
 import java.util.Set;
@@ -29,6 +30,7 @@ public class GatewayMessageParser {
         super();
         this.xmlMapper = xmlMapper;
         this.validator = validator;
+        this.xmlMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     public MessageType parseMessage (String xml) throws IOException {
@@ -42,6 +44,10 @@ public class GatewayMessageParser {
         if (!errors.isEmpty()) {
             throw new ConstraintViolationException(errors);
         }
+        if (messageType.getMessageBody() == null) {
+            throw new ConstraintViolationException("null message body", null);
+        }
+
     }
 
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/MessageType.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/MessageType.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Data
 @JacksonXmlRootElement(localName = "CSCI_Message_Type")
+@Valid
 public class MessageType {
 
     @NotNull

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Case.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Case.java
@@ -2,7 +2,6 @@ package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -25,17 +24,14 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @Builder
 @Data
-@JsonIgnoreProperties(value = {"h_id", "valid", "type", "prov", "urn", "asn", "marker", "linked", "inf", "pg_type", "pg_name", "pg_addr", "sol_name"})
 public class Case {
 
-    @NotNull
     @JacksonXmlProperty(localName = "c_id")
     private final Long id;
 
     @NotBlank
     @JacksonXmlProperty(localName = "caseno")
     private final String caseNo;
-    @NotNull
     @PositiveOrZero
     @JacksonXmlProperty(localName = "cseq")
     private final Integer seq;
@@ -43,17 +39,13 @@ public class Case {
     @JacksonXmlProperty(localName = "def_name_elements")
     private final Name name;
 
-    @NotNull
     private final String def_name;
-    @NotNull
     private final String def_type;
-    @NotNull
     private final String def_sex;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy", lenient = OptBoolean.TRUE)
     @JsonDeserialize(using = LocalDateDeserializer.class)
     private final LocalDate def_dob;
-    @NotNull
     @JacksonXmlProperty(localName = "def_addr")
     private final Address def_addr;
     private final String def_age;
@@ -64,7 +56,6 @@ public class Case {
     @JacksonXmlProperty(localName = "pnc_id")
     private final String pnc;
 
-    @NotBlank
     @JacksonXmlProperty(localName = "listno")
     private final String listNo;
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Document.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Document.java
@@ -1,7 +1,6 @@
 
 package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -16,7 +15,6 @@ import lombok.ToString;
 @AllArgsConstructor
 @Builder
 @Data
-@JsonIgnoreProperties(value = "jsonData")
 public class Document
 {
     @Valid

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/ExternalDocumentRequest.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/ExternalDocumentRequest.java
@@ -5,7 +5,6 @@ import static uk.gov.justice.probation.courtcasematcher.messaging.GatewayMessage
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +18,6 @@ import lombok.NoArgsConstructor;
 public class ExternalDocumentRequest
 {
     @JacksonXmlProperty(namespace = EXT_DOC_NS, localName = "documents")
-    @NotNull
     @Valid
     private final DocumentWrapper documentWrapper;
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Info.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Info.java
@@ -2,12 +2,12 @@
 package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import java.time.LocalDate;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,14 +22,15 @@ import uk.gov.justice.probation.courtcasematcher.messaging.SourceFileNameDeseria
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
-@JsonIgnoreProperties(value = {"contentType"})
 public class Info {
 
     @Exclude
+    @NotNull
     @JsonDeserialize(using = SourceFileNameDeserializer.class)
     @JacksonXmlProperty(localName = "source_file_name")
     private final InfoSourceDetail infoSourceDetail;
 
+    @NotNull
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy", lenient = OptBoolean.TRUE)
     @JsonDeserialize(using = LocalDateDeserializer.class)
     private final LocalDate dateOfHearing;

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Job.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Job.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.List;
@@ -18,13 +17,11 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @Builder
 @Data
-@JsonIgnoreProperties(value = {"printdate", "username", "late", "adbox", "means"})
 public class Job {
 
     @ToString.Exclude
     @JsonManagedReference
     @JacksonXmlElementWrapper
-    @NotEmpty
     private final List<@Valid Session> sessions;
 
     @JsonBackReference

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Offence.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Offence.java
@@ -1,8 +1,6 @@
 package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 import lombok.AccessLevel;
@@ -15,8 +13,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @Builder
 @Data
-@JsonIgnoreProperties(value = {"co_id", "code", "maxpen", "cy_title", "alm", "ala", "cy_sum", "cy_as", "sof", "cy_sof",
-                                "adjdate", "adjreason", "plea", "pleadate", "convdate"})
 public class Offence {
 
     @NotNull
@@ -24,9 +20,7 @@ public class Offence {
     @JacksonXmlProperty(localName = "oseq")
     private final Integer seq;
 
-    @NotBlank
     private final String sum;
-    @NotBlank
     private final String title;
     private final String as;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/externaldocumentrequest/Session.java
@@ -1,8 +1,11 @@
 package uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -10,10 +13,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -28,10 +27,8 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @Builder
 @Data
-@JsonIgnoreProperties(value = {"lja", "cmu", "area_code", "panel"})
 public class Session {
 
-    @NotNull
     @JacksonXmlProperty(localName = "s_id")
     private final Long id;
 
@@ -41,22 +38,18 @@ public class Session {
     @NotNull
     private final LocalDate dateOfHearing;
 
-    @NotNull
     @JacksonXmlProperty(localName = "court")
     private final String courtName;
-    @NotNull
     @JacksonXmlProperty(localName = "room")
     private final String courtRoom;
     @JacksonXmlProperty(localName = "ou_code")
     private final String courtCode;
-
 
     @NotNull
     @JsonDeserialize(using = LocalTimeDeserializer.class)
     @JacksonXmlProperty(localName = "sstart")
     private final LocalTime start;
 
-    @NotNull
     @JsonDeserialize(using = LocalTimeDeserializer.class)
     @JacksonXmlProperty(localName = "send")
     private final LocalTime end;

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParserTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParserTest.java
@@ -63,16 +63,13 @@ public class GatewayMessageParserTest {
         Throwable thrown = catchThrowable(() -> gatewayMessageParser.parseMessage(content));
 
         ConstraintViolationException ex = (ConstraintViolationException) thrown;
-        assertThat(ex.getConstraintViolations()).hasSize(4);
+        assertThat(ex.getConstraintViolations()).hasSize(2);
+        final String docInfoPath = "messageBody.gatewayOperationType.externalDocumentRequest.documentWrapper.document[0].info";
         final String firstSessionPath = "messageBody.gatewayOperationType.externalDocumentRequest.documentWrapper.document[0].data.job.sessions[0]";
         assertThat(ex.getConstraintViolations()).anyMatch(cv -> cv.getMessage().equals("must not be null")
-            && cv.getPropertyPath().toString().equals(firstSessionPath + ".courtRoom"));
-        assertThat(ex.getConstraintViolations()).anyMatch(cv -> cv.getMessage().equals("must not be null")
-            && cv.getPropertyPath().toString().equals(firstSessionPath + ".id"));
+            && cv.getPropertyPath().toString().equals(docInfoPath + ".dateOfHearing"));
         assertThat(ex.getConstraintViolations()).anyMatch(cv -> cv.getMessage().equals("must not be blank")
             && cv.getPropertyPath().toString().equals(firstSessionPath + ".blocks[0].cases[0].caseNo"));
-        assertThat(ex.getConstraintViolations()).anyMatch(cv -> cv.getMessage().equals("must not be blank")
-            && cv.getPropertyPath().toString().equals(firstSessionPath + ".blocks[0].cases[0].offences[0].title"));
     }
 
     @DisplayName("Parse a valid message")

--- a/src/test/resources/messages/gateway-message-multi-session.xml
+++ b/src/test/resources/messages/gateway-message-multi-session.xml
@@ -40,6 +40,7 @@
                                         <doh>20/02/2020</doh>
                                         <lja>South West London Magistrates; Court</lja>
                                         <cmu>Gl Management Unit 1</cmu>
+                                        <someUnknownFieldWhichWeCanIgnore>hello</someUnknownFieldWhichWeCanIgnore>
                                         <panel>Adult Panel</panel>
                                         <court>Camberwell Green</court>
                                         <room>00</room>


### PR DESCRIPTION
…rather what we need for the database

Also, there is some suggestion that we might get fields we are not expecting. So rather than ignore them in the classes with an annotation, there is a directive to XmlMapper itself.