### PR TITLE
✨ Support for > 1 match and refactoring work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,8 @@ dependencies {
     testCompile "com.github.tomakehurst:wiremock-jre8:2.26.3"
     testCompile 'org.mockito:mockito-core:3.5.10'
     testCompile 'org.apache.activemq:artemis-junit:2.15.0'
+    testCompile 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.projectlombok:lombok'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     runtimeOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
@@ -100,9 +100,7 @@ dependencies {
     testCompile "com.github.tomakehurst:wiremock-jre8:2.26.3"
     testCompile 'org.mockito:mockito-core:3.5.10'
     testCompile 'org.apache.activemq:artemis-junit:2.15.0'
-    testCompile 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-
 }
 
 test {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/event/CourtCaseMatchEvent.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/event/CourtCaseMatchEvent.java
@@ -1,25 +1,19 @@
 package uk.gov.justice.probation.courtcasematcher.event;
 
-import java.util.Set;
-import javax.validation.ConstraintViolation;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 
 @Getter
 @Slf4j
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
-public class CourtCaseFailureEvent {
+public class CourtCaseMatchEvent {
 
-    private final String incomingMessage;
-
-    private final String failureMessage;
-
-    private final Set<ConstraintViolation<?>> violations;
-
+    private final CourtCase courtCase;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/event/CourtCaseSuccessEvent.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/event/CourtCaseSuccessEvent.java
@@ -1,15 +1,20 @@
 package uk.gov.justice.probation.courtcasematcher.event;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 
 @Getter
 @Slf4j
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class CourtCaseSuccessEvent {
 
-    private final CourtCase courtCaseApi;
+    private final CourtCase courtCase;
 
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/event/CourtCaseUpdateEvent.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/event/CourtCaseUpdateEvent.java
@@ -1,25 +1,18 @@
 package uk.gov.justice.probation.courtcasematcher.event;
 
-import java.util.Set;
-import javax.validation.ConstraintViolation;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 
 @Getter
 @Slf4j
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
-public class CourtCaseFailureEvent {
-
-    private final String incomingMessage;
-
-    private final String failureMessage;
-
-    private final Set<ConstraintViolation<?>> violations;
-
+public class CourtCaseUpdateEvent {
+    private final CourtCase courtCase;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/event/EventListener.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/event/EventListener.java
@@ -5,8 +5,12 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
+import uk.gov.justice.probation.courtcasematcher.service.CourtCaseService;
+import uk.gov.justice.probation.courtcasematcher.service.MatcherService;
 
 /**
  * We intend to replace EventBus with an external message queue.
@@ -15,12 +19,19 @@ import org.springframework.util.CollectionUtils;
 @Slf4j
 public class EventListener {
 
+    private final CourtCaseService courtCaseService;
+
+    private final MatcherService matcherService;
+
     private final AtomicLong successCount = new AtomicLong(0);
 
     private final AtomicLong failureCount = new AtomicLong(0);
 
-    public EventListener(EventBus eventBus) {
+    @Autowired
+    public EventListener(EventBus eventBus, MatcherService matcherService, CourtCaseService courtCaseService) {
         super();
+        this.matcherService = matcherService;
+        this.courtCaseService = courtCaseService;
         eventBus.register(this);
     }
 
@@ -39,10 +50,32 @@ public class EventListener {
     @AllowConcurrentEvents
     @Subscribe
     public void courtCaseEvent(CourtCaseSuccessEvent courtCaseEvent) {
-        String caseNo = courtCaseEvent.getCourtCaseApi().getCaseNo();
-        String court = courtCaseEvent.getCourtCaseApi().getCourtCode();
+        String caseNo = courtCaseEvent.getCourtCase().getCaseNo();
+        String court = courtCaseEvent.getCourtCase().getCourtCode();
         log.info("EventBus success event for posting case {} for court {}. Total count of successful messages {} ",
             caseNo, court, successCount.incrementAndGet());
+    }
+
+    @AllowConcurrentEvents
+    @Subscribe
+    public void courtCaseUpdateEvent(CourtCaseUpdateEvent courtCaseEvent) {
+        CourtCase courtCase = courtCaseEvent.getCourtCase();
+        log.info("Upsert case no {} for court {}", courtCase.getCaseNo(), courtCase.getCourtCode());
+        courtCaseService.saveCourtCase(courtCaseEvent.getCourtCase());
+    }
+
+    @AllowConcurrentEvents
+    @Subscribe
+    public void courtCaseMatchEvent(CourtCaseMatchEvent courtCaseEvent) {
+
+        CourtCase courtCase = courtCaseEvent.getCourtCase();
+        log.info("Matching offender and saving case no {} for court {}, defendant name {}",
+            courtCase.getCaseNo(), courtCase.getCourtCode(), courtCase.getDefendantName());
+
+        matcherService.getSearchResponse(courtCase.getDefendantName(), courtCase.getDefendantDob(), courtCase.getCourtCode(), courtCase.getCaseNo())
+            .subscribe(searchResponse -> {
+                courtCaseService.createCase(courtCase, searchResponse);
+            });
     }
 
     public long getSuccessCount() {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessor.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessor.java
@@ -1,10 +1,8 @@
 package uk.gov.justice.probation.courtcasematcher.messaging;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import com.google.common.eventbus.EventBus;
 import javax.validation.ConstraintViolationException;
@@ -14,11 +12,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseFailureEvent;
+import uk.gov.justice.probation.courtcasematcher.event.CourtCaseMatchEvent;
+import uk.gov.justice.probation.courtcasematcher.event.CourtCaseUpdateEvent;
 import uk.gov.justice.probation.courtcasematcher.model.MessageHeader;
 import uk.gov.justice.probation.courtcasematcher.model.MessageType;
-import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.DocumentWrapper;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
+import uk.gov.justice.probation.courtcasematcher.service.CourtCaseService;
 import uk.gov.justice.probation.courtcasematcher.service.MatcherService;
 
 @Setter
@@ -36,14 +37,18 @@ public class MessageProcessor {
 
     private final MatcherService matcherService;
 
+    private final CourtCaseService courtCaseService;
+
     @Autowired
     public MessageProcessor(GatewayMessageParser gatewayMessageParser,
                             EventBus eventBus,
-                            MatcherService matcherService) {
+                            MatcherService matcherService,
+                            CourtCaseService courtCaseService) {
         super();
         this.parser = gatewayMessageParser;
         this.eventBus = eventBus;
         this.matcherService = matcherService;
+        this.courtCaseService = courtCaseService;
     }
 
     public void process(String message) {
@@ -80,31 +85,33 @@ public class MessageProcessor {
             .flatMap(document -> document.getData().getJob().getSessions().stream())
             .collect(Collectors.toList());
 
-        List<CompletableFuture<Long>> futures = matchCases(sessions);
-
-        CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).thenRun(() -> {
-            MessageProcessorUtils.getCourtCodes(sessions).forEach(courtCode ->  {
-                log.debug("Completed handling cases for court {}", courtCode);
-            });
-        });
+        saveCases(sessions);
     }
 
-    private List<CompletableFuture<Long>> matchCases(List<Session> sessions) {
-
-        List<CompletableFuture<Long>> allFutures = new ArrayList<>();
+    private void saveCases(List<Session> sessions) {
         sessions.forEach(session -> {
-            List<Case> cases = session.getBlocks().stream()
+            log.debug("Starting to process cases in session court {}, room {}, date {}",
+                session.getCourtCode(), session.getCourtRoom(), session.getDateOfHearing());
+
+            List<String> cases = session.getBlocks().stream()
                 .flatMap(block -> block.getCases().stream())
+                .map(aCase -> {
+                    courtCaseService.getCourtCase(aCase)
+                        .subscribe(this::postCaseEvent);
+                    return aCase.getCaseNo();
+                })
                 .collect(Collectors.toList());
-            allFutures.add(CompletableFuture.supplyAsync(() -> matchCases(session, cases)));
+            log.debug("Completed {} cases for {}, {}, {}", cases.size(), session.getCourtCode(), session.getCourtRoom(), session.getDateOfHearing());
         });
-        return allFutures;
     }
 
-    private Long matchCases(Session session, List<Case> cases) {
-        log.debug("Matching {} cases for court {}, session {}", cases.size(), session.getCourtCode(), session.getId());
-        cases.forEach(matcherService::match);
-        return session.getId();
+    void postCaseEvent(CourtCase courtCase) {
+        if (courtCase.isNew()) {
+            eventBus.post(CourtCaseMatchEvent.builder().courtCase(courtCase).build());
+        }
+        else {
+            eventBus.post(CourtCaseUpdateEvent.builder().courtCase(courtCase).build());
+        }
     }
 
     private void logMessageReceipt(MessageHeader messageHeader) {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessor.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessor.java
@@ -107,10 +107,10 @@ public class MessageProcessor {
 
     void postCaseEvent(CourtCase courtCase) {
         if (courtCase.isNew()) {
-            eventBus.post(CourtCaseMatchEvent.builder().courtCase(courtCase).build());
+            eventBus.post(new CourtCaseMatchEvent(courtCase));
         }
         else {
-            eventBus.post(CourtCaseUpdateEvent.builder().courtCase(courtCase).build());
+            eventBus.post(new CourtCaseUpdateEvent(courtCase));
         }
     }
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/CourtCase.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/courtcaseservice/CourtCase.java
@@ -64,4 +64,7 @@ public class CourtCase implements Serializable {
     @JsonIgnore
     private final GroupedOffenderMatches groupedOffenderMatches;
 
+    @JsonIgnore
+    private final boolean isNew;
+
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
@@ -6,9 +6,13 @@ import org.springframework.stereotype.Component;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Address;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.MatchIdentifiers;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Offence;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderMatch;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
-import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Match;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +35,28 @@ public class CaseMapper {
 
     public CourtCase newFromCase(Case aCase) {
         return getCourtCaseBuilderFromCase(aCase)
+            .isNew(true)
             .build();
+    }
+
+    private CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(CourtCase courtCase) {
+        return CourtCase.builder()
+            .caseNo(courtCase.getCaseNo())
+            .courtCode(courtCase.getCourtCode())
+            .caseId(String.valueOf(courtCase.getCaseId()))
+            .courtRoom(courtCase.getCourtRoom())
+            .defendantAddress(courtCase.getDefendantAddress())
+            .defendantName(courtCase.getDefendantName())
+            .defendantDob(courtCase.getDefendantDob())
+            .defendantSex(courtCase.getDefendantSex())
+            .cro(courtCase.getCro())
+            .pnc(courtCase.getPnc())
+            .listNo(courtCase.getListNo())
+            .sessionStartTime(courtCase.getSessionStartTime())
+            .probationStatus(defaultProbationStatus)
+            .nationality1(courtCase.getNationality1())
+            .nationality2(courtCase.getNationality2())
+            .offences(courtCase.getOffences());
     }
 
     private CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(Case aCase) {
@@ -104,14 +129,61 @@ public class CaseMapper {
             .build();
     }
 
-    public CourtCase newFromCaseAndOffender(Case incomingCase, Offender offender, String probationStatus, GroupedOffenderMatches groupedOffenderMatches) {
-        return getCourtCaseBuilderFromCase(incomingCase)
-                .probationStatus(probationStatus != null ? probationStatus : defaultProbationStatus)
-                .crn(offender.getOtherIds().getCrn())
-                .cro(offender.getOtherIds().getCro())
-                .pnc(offender.getOtherIds().getPnc())
-                .groupedOffenderMatches(groupedOffenderMatches)
+    public CourtCase newFromCourtCaseAndSearchResponse(CourtCase incomingCase, SearchResponse searchResponse) {
+
+        List<Match> matches = searchResponse.getMatches() != null ? searchResponse.getMatches() : Collections.emptyList();
+        MatchType matchType = MatchType.of(searchResponse.getMatchedBy());
+
+        CourtCase courtCase;
+        if (matches.size() == 1) {
+            Match match = searchResponse.getMatches().get(0);
+
+            courtCase = getCourtCaseBuilderFromCase(incomingCase)
+                .probationStatus(Optional.ofNullable(searchResponse.getProbationStatus()).orElse(defaultProbationStatus))
+                .crn(match.getOffender().getOtherIds().getCrn())
+                .cro(match.getOffender().getOtherIds().getCro())
+                .pnc(match.getOffender().getOtherIds().getPnc())
+                .groupedOffenderMatches(buildGroupedOffenderMatch(match, matchType))
                 .build();
+        }
+        else {
+            courtCase = getCourtCaseBuilderFromCase(incomingCase)
+                .groupedOffenderMatches(buildGroupedOffenderMatch(searchResponse.getMatches(), matchType))
+                .build();
+        }
+
+        return courtCase;
     }
 
+    private GroupedOffenderMatches buildGroupedOffenderMatch (Match offenderMatch, MatchType matchType) {
+
+        return GroupedOffenderMatches.builder()
+            .matches(Collections.singletonList(buildOffenderMatch(matchType, offenderMatch)))
+            .build();
+    }
+
+    private GroupedOffenderMatches buildGroupedOffenderMatch (List<Match> matches, MatchType matchType) {
+
+        if (matches == null || matches.isEmpty()) {
+            return GroupedOffenderMatches.builder().matches(Collections.emptyList()).build();
+        }
+        return GroupedOffenderMatches.builder()
+            .matches(matches.stream()
+                .map(match -> buildOffenderMatch(matchType, match))
+                .collect(Collectors.toList()))
+            .build();
+    }
+
+    private OffenderMatch buildOffenderMatch(MatchType matchType, Match match) {
+        return OffenderMatch.builder()
+            .rejected(false)
+            .confirmed(false)
+            .matchType(matchType)
+            .matchIdentifiers(MatchIdentifiers.builder()
+                .pnc(match.getOffender().getOtherIds().getPnc())
+                .cro(match.getOffender().getOtherIds().getCro())
+                .crn(match.getOffender().getOtherIds().getCrn())
+                .build())
+            .build();
+    }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/MatchType.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/MatchType.java
@@ -1,14 +1,31 @@
 package uk.gov.justice.probation.courtcasematcher.model.offendersearch;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public enum MatchType {
-    NAME_DOB;
+    NAME_DOB,
+    NAME,
+    PARTIAL_NAME,
+    PARTIAL_NAME_DOB_LENIENT,
+    NOTHING,
+    UNKNOWN;
 
     public static MatchType of(OffenderSearchMatchType offenderSearchMatchType) {
         switch (offenderSearchMatchType) {
             case ALL_SUPPLIED:
                 return NAME_DOB;
+            case NAME:
+                return NAME;
+            case PARTIAL_NAME:
+                return PARTIAL_NAME;
+            case PARTIAL_NAME_DOB_LENIENT:
+                return PARTIAL_NAME_DOB_LENIENT;
+            case NOTHING:
+                return NOTHING;
             default:
-                return null;
+                log.warn("Unknown OffenderSearchMatchType received {}", offenderSearchMatchType.name());
+                return UNKNOWN;
         }
     }
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
@@ -4,8 +4,8 @@ import lombok.*;
 
 import java.util.List;
 
-@Getter
 @Builder
+@Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @ToString

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
@@ -8,7 +8,9 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+@ToString
 public class SearchResponse {
     private final List<Match> matches;
     private final OffenderSearchMatchType matchedBy;
+    private final String probationStatus;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
@@ -1,6 +1,11 @@
 package uk.gov.justice.probation.courtcasematcher.restclient;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 import com.google.common.eventbus.EventBus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,19 +23,11 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseSuccessEvent;
-import uk.gov.justice.probation.courtcasematcher.event.OffenderSearchFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderDetail;
 import uk.gov.justice.probation.courtcasematcher.restclient.exception.CourtCaseNotFoundException;
 import uk.gov.justice.probation.courtcasematcher.restclient.exception.CourtNotFoundException;
-
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Supplier;
 
 import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcasematcher.restclient;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.eventbus.EventBus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,7 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseSuccessEvent;
+import uk.gov.justice.probation.courtcasematcher.event.OffenderSearchFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderDetail;
@@ -133,13 +135,13 @@ public class CourtCaseRestClient {
         return get(path)
             .retrieve()
             .bodyToMono(OffenderDetail.class)
-            .onErrorResume((e) -> {
-                log.info("GET failed for retrieving the offender probation status for path {}", path, e);
-                return Mono.empty();
-            })
             .map(offenderDetail -> {
                 log.info("GET succeeded for retrieving the offender probation status for path {}", path);
                 return offenderDetail.getProbationStatus();
+            })
+            .onErrorResume((e) -> {
+                log.info("GET failed for retrieving the offender probation status for path {}. Will return empty status", path, e);
+                return Mono.just("");
             });
     }
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
@@ -91,7 +91,7 @@ public class CourtCaseRestClient {
             .bodyToMono(CourtCase.class)
             .doOnError(e -> postErrorToBus(String.format(ERR_MSG_FORMAT_PUT_CASE, caseNo, courtCode) + ".Exception : " + e))
             .subscribe(courtCaseApi -> {
-                eventBus.post(CourtCaseSuccessEvent.builder().courtCaseApi(courtCaseApi).build());
+                eventBus.post(CourtCaseSuccessEvent.builder().courtCase(courtCaseApi).build());
                 postMatches(courtCaseApi.getCourtCode(), courtCaseApi.getCaseNo(), offenderMatches);
             });
     }
@@ -126,7 +126,7 @@ public class CourtCaseRestClient {
             });
     }
 
-    public Mono<String> getOffenderProbationStatus(String crn) {
+    public Mono<String> getProbationStatus(String crn) {
         final String path = String.format(offenderDetailGetTemplate, crn);
 
         // Get the existing case. Not a problem if it's not there. So return a Mono.empty() if it's not

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseService.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import lombok.AllArgsConstructor;
@@ -41,14 +42,13 @@ public class CourtCaseService {
 
     public void createCase(CourtCase courtCase, SearchResponse searchResponse) {
 
-        if (searchResponse == null) {
-            log.debug("Save court case with no search response for case {}, court {}", courtCase.getCaseNo(), courtCase.getCourtCode());
-            saveCourtCase(courtCase);
-        }
-        else {
-            log.debug("Save court case with search response for case {}, court {}", courtCase.getCaseNo(), courtCase.getCourtCode());
-            saveCourtCase(caseMapper.newFromCourtCaseAndSearchResponse(courtCase, searchResponse));
-        }
+        Optional.ofNullable(searchResponse)
+            .ifPresentOrElse(response -> {
+                    log.debug("Save court case with search response for case {}, court {}",
+                        courtCase.getCaseNo(), courtCase.getCourtCode());
+                    saveCourtCase(caseMapper.newFromCourtCaseAndSearchResponse(courtCase, response));
+                },
+                () -> saveCourtCase(courtCase));
     }
 
     public void saveCourtCase(CourtCase courtCase) {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
@@ -1,24 +1,16 @@
 package uk.gov.justice.probation.courtcasematcher.service;
 
-import static uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType.ALL_SUPPLIED;
-
-import java.util.Collections;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
-import reactor.util.function.Tuple2;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.MatchIdentifiers;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderMatch;
-import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
-import uk.gov.justice.probation.courtcasematcher.model.mapper.CaseMapper;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Match;
-import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 import uk.gov.justice.probation.courtcasematcher.restclient.CourtCaseRestClient;
 import uk.gov.justice.probation.courtcasematcher.restclient.OffenderSearchRestClient;
@@ -35,64 +27,36 @@ public class MatcherService {
     @Autowired
     private final OffenderSearchRestClient offenderSearchRestClient;
 
-    @Autowired
-    private final CaseMapper caseMapper;
-
-    public void match(Case incomingCase) {
-        restClient.getCourtCase(incomingCase.getBlock().getSession().getCourtCode(), incomingCase.getCaseNo())
-                .map(existing -> caseMapper.merge(incomingCase, existing))
-                .switchIfEmpty(Mono.defer(() -> newMatchedCaseOf(incomingCase)))
-                .switchIfEmpty(Mono.defer(() -> Mono.just(caseMapper.newFromCase(incomingCase))))
-                .map(courtCase -> restClient.putCourtCase(courtCase.getCourtCode(), courtCase.getCaseNo(), courtCase))
-                .block();
-    }
-
-    private Mono<CourtCase> newMatchedCaseOf(Case incomingCase) {
-        final String courtCode = incomingCase.getBlock().getSession().getCourtCode();
-        final String caseNo = incomingCase.getCaseNo();
-        return offenderSearchRestClient.search(incomingCase.getDef_name(), incomingCase.getDef_dob())
+    public Mono<SearchResponse> getSearchResponse(String defendantName, LocalDate dateOfBirth, String courtCode, String caseNo) {
+        return offenderSearchRestClient.search(defendantName, dateOfBirth)
                 .map(searchResponse -> {
                     log.info(String.format("Match results for caseNo: %s, courtCode: %s - matchedBy: %s, matchCount: %s",
                         caseNo, courtCode, searchResponse.getMatchedBy(), searchResponse.getMatches() == null ? "null" : searchResponse.getMatches().size()));
                     return searchResponse;
                 })
-                .filter(searchResponse -> searchResponse.getMatchedBy() == ALL_SUPPLIED)
-                .map(SearchResponse::getMatches)
-                .flatMap(matches -> {
-                    if (matches != null && matches.size() == 1)
-                        return Mono.zip(Mono.just(matches.get(0)), restClient.getOffenderProbationStatus(matches.get(0).getOffender().getOtherIds().getCrn()));
-                    else
-                        return Mono.empty();
+                .flatMap(searchResponse -> {
+                    List<Match> matches = searchResponse.getMatches();
+                    if (matches != null && matches.size() == 1) {
+                        return Mono.zip(Mono.just(searchResponse), restClient.getProbationStatus(matches.get(0).getOffender().getOtherIds().getCrn()));
+                    }
+                    else {
+                        log.info("RETURN NOT 1 {}, {}", searchResponse.getMatchedBy(), searchResponse.getMatches().size());
+                        return Mono.zip(Mono.just(searchResponse), Mono.just(""));
+                    }
                 })
-                .map(tuple2 -> buildNewCase(tuple2, incomingCase))
-                // Ideally we would avoid blocking at this point and continue with Mono processing
+                .map(tuple2 -> combine(tuple2.getT1(), tuple2.getT2()))
                 .doOnSuccess((data) -> {
                     if (data == null) {
                         log.error(String.format("Match results for caseNo: %s, courtCode: %s - Empty response from OffenderSearchRestClient",
-                            incomingCase.getCaseNo(), incomingCase.getBlock().getSession().getCourtCode()));
+                            caseNo, courtCode));
                     }
                 });
     }
 
-    private CourtCase buildNewCase(Tuple2<Match, String> tuple, Case incomingCase) {
-        Match match = tuple.getT1();
-        String probationStatus = tuple.getT2();
-        return caseMapper.newFromCaseAndOffender(incomingCase, match.getOffender(), probationStatus, buildGroupedOffenderMatch(match, MatchType.of(ALL_SUPPLIED)));
-    }
-
-    private GroupedOffenderMatches buildGroupedOffenderMatch (Match offenderMatch, MatchType matchType) {
-
-        return GroupedOffenderMatches.builder()
-            .matches(Collections.singletonList(OffenderMatch.builder()
-                        .confirmed(false)
-                        .rejected(false)
-                        .matchType(matchType)
-                        .matchIdentifiers(MatchIdentifiers.builder()
-                            .pnc(offenderMatch.getOffender().getOtherIds().getPnc())
-                            .cro(offenderMatch.getOffender().getOtherIds().getCro())
-                            .crn(offenderMatch.getOffender().getOtherIds().getCrn())
-                            .build())
-                        .build()))
+    public SearchResponse combine(SearchResponse searchResponse, String probationStatus) {
+        return SearchResponse.builder().matchedBy(searchResponse.getMatchedBy())
+            .probationStatus(StringUtils.isEmpty(probationStatus) ? null : probationStatus)
+            .matches(searchResponse.getMatches())
             .build();
     }
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
@@ -40,7 +40,8 @@ public class MatcherService {
                         return Mono.zip(Mono.just(searchResponse), restClient.getProbationStatus(matches.get(0).getOffender().getOtherIds().getCrn()));
                     }
                     else {
-                        log.info("RETURN NOT 1 {}, {}", searchResponse.getMatchedBy(), searchResponse.getMatches().size());
+                        log.debug("Got {} matches for defendant name {}, dob {}, match type {}",
+                            searchResponse.getMatches().size(), defendantName, dateOfBirth, searchResponse.getMatchedBy());
                         return Mono.zip(Mono.just(searchResponse), Mono.just(""));
                     }
                 })

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
@@ -15,6 +15,7 @@ import ch.qos.logback.core.Appender;
 import com.google.common.eventbus.EventBus;
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
@@ -30,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 import uk.gov.justice.probation.courtcasematcher.service.CourtCaseService;
 import uk.gov.justice.probation.courtcasematcher.service.MatcherService;
@@ -160,8 +162,7 @@ class EventListenerTest {
         verify(courtCaseService).createCase(courtCase, searchResponse);
     }
 
-    @Disabled
-    @DisplayName("Check the match event when the call to the matcher service fails")
+    @DisplayName("Check the match event when the call to the matcher service returns an empty response")
     @Test
     void givenSearchWhichFails_whenCourtCaseMatched_thenSave() {
         when(matcherService.getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE)).thenReturn(Mono.empty());
@@ -169,7 +170,10 @@ class EventListenerTest {
         eventListener.courtCaseMatchEvent(CourtCaseMatchEvent.builder().courtCase(courtCase).build());
 
         verify(matcherService).getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE);
-        verify(courtCaseService).createCase(courtCase, null);
+        verify(courtCaseService).createCase(courtCase, SearchResponse.builder()
+                                                                        .matches(Collections.emptyList())
+                                                                        .matchedBy(OffenderSearchMatchType.NOTHING)
+                                                                        .build());
     }
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
@@ -13,6 +13,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.google.common.eventbus.EventBus;
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
@@ -26,10 +28,32 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
+import uk.gov.justice.probation.courtcasematcher.service.CourtCaseService;
+import uk.gov.justice.probation.courtcasematcher.service.MatcherService;
 
 @ExtendWith(MockitoExtension.class)
 class EventListenerTest {
+
+
+    private final static String DEFENDANT_NAME = "Nic CAGE";
+    private final static LocalDate DEFENDANT_DOB = LocalDate.of(1955, Month.SEPTEMBER, 25);
+    private final static String CASE = "123456";
+    private final static String COURT_CODE = "B10JQ00";
+    private final static CourtCase courtCase = CourtCase.builder()
+        .defendantName(DEFENDANT_NAME)
+        .defendantDob(DEFENDANT_DOB)
+        .courtCode(COURT_CODE)
+        .caseNo(CASE)
+        .build();
+
+    @Mock
+    private MatcherService matcherService;
+
+    @Mock
+    private CourtCaseService courtCaseService;
 
     @Mock
     private Appender<ILoggingEvent> mockAppender;
@@ -47,7 +71,7 @@ class EventListenerTest {
         logger.addAppender(mockAppender);
 
         eventBus = new EventBus();
-        eventListener = new EventListener(eventBus);
+        eventListener = new EventListener(eventBus, matcherService, courtCaseService);
     }
 
     @DisplayName("Ensure that successful events are logged and counted")
@@ -55,7 +79,7 @@ class EventListenerTest {
     void testSuccessEvent() {
         CourtCase courtCaseApi = CourtCase.builder().caseNo("123").courtCode("SHF").build();
 
-        eventListener.courtCaseEvent(CourtCaseSuccessEvent.builder().courtCaseApi(courtCaseApi).build());
+        eventListener.courtCaseEvent(CourtCaseSuccessEvent.builder().courtCase(courtCaseApi).build());
 
         verify(mockAppender, atLeast(1)).doAppend(captorLoggingEvent.capture());
         List<LoggingEvent> events = captorLoggingEvent.getAllValues();
@@ -115,6 +139,37 @@ class EventListenerTest {
         eventBus.post(CourtCaseFailureEvent.builder().failureMessage("Problem").build());
 
         assertThat(eventListener.getFailureCount()).isEqualTo(1);
+    }
+
+    @DisplayName("Check the match event when the call to the matcher service returns")
+    @Test
+    void whenCourtCaseUpdated_thenSave() {
+        eventListener.courtCaseUpdateEvent(CourtCaseUpdateEvent.builder().courtCase(courtCase).build());
+
+        verify(courtCaseService).saveCourtCase(courtCase);
+    }
+
+    @DisplayName("Check the match event when the call to the matcher service returns")
+    @Test
+    void givenSearch_whenCourtCaseMatched_thenSave() {
+        SearchResponse searchResponse = SearchResponse.builder().build();
+        when(matcherService.getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE)).thenReturn(Mono.just(searchResponse));
+
+        eventBus.post(CourtCaseMatchEvent.builder().courtCase(courtCase).build());
+
+        verify(courtCaseService).createCase(courtCase, searchResponse);
+    }
+
+    @Disabled
+    @DisplayName("Check the match event when the call to the matcher service fails")
+    @Test
+    void givenSearchWhichFails_whenCourtCaseMatched_thenSave() {
+        when(matcherService.getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE)).thenReturn(Mono.empty());
+
+        eventListener.courtCaseMatchEvent(CourtCaseMatchEvent.builder().courtCase(courtCase).build());
+
+        verify(matcherService).getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE);
+        verify(courtCaseService).createCase(courtCase, null);
     }
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParserTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/GatewayMessageParserTest.java
@@ -117,7 +117,7 @@ public class GatewayMessageParserTest {
 
     private void checkBlock(Block block) {
         assertThat(block.getCases()).hasSize(2);
-        checkCase(block.getCases().stream().filter(aCase -> aCase.getCaseNo().equals("1600032952")).findFirst().orElseThrow());
+        checkCase(block.getCases().stream().filter(aCase -> aCase.getCaseNo().equals("1600032953")).findFirst().orElseThrow());
     }
 
     private void checkCase(Case aCase) {

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageProcessorTest.java
@@ -1,57 +1,61 @@
 package uk.gov.justice.probation.courtcasematcher.messaging;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.eventbus.EventBus;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.eventbus.EventBus;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
+import lombok.Builder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseFailureEvent;
+import uk.gov.justice.probation.courtcasematcher.event.CourtCaseMatchEvent;
+import uk.gov.justice.probation.courtcasematcher.event.CourtCaseUpdateEvent;
 import uk.gov.justice.probation.courtcasematcher.model.MessageType;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
+import uk.gov.justice.probation.courtcasematcher.service.CourtCaseService;
 import uk.gov.justice.probation.courtcasematcher.service.MatcherService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @DisplayName("Message Processor")
 @ExtendWith(MockitoExtension.class)
 class MessageProcessorTest {
 
-    private static final String COURT_CODE = "B01CX00";
-    public static final String CASE_NO = "1600032952";
-
     private static final long MATCHER_THREAD_TIMEOUT = 4000;
     private static String singleCaseXml;
     private static String multiSessionXml;
     private static String multiDayXml;
-    private static String singleDayXml;
-    private static String singleDayFutureXml;
-    private static String multiCourtXml;
 
     @Mock
     private EventBus eventBus;
 
     @Mock
     private MatcherService matcherService;
+
+    @Mock
+    private CourtCaseService courtCaseService;
 
     @Mock
     private Validator validator;
@@ -74,15 +78,15 @@ class MessageProcessorTest {
         multiDayXml = Files.readString(Paths.get(multiDayPath));
 
         String singleDayPath = "src/test/resources/messages/gateway-message-single-day.xml";
-        singleDayXml = Files.readString(Paths.get(singleDayPath));
+        String singleDayXml = Files.readString(Paths.get(singleDayPath));
         singleDayXml = singleDayXml.replace("[TODAY]", LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
 
         String singleDayFuturePath = "src/test/resources/messages/gateway-message-single-day-future.xml";
-        singleDayFutureXml = Files.readString(Paths.get(singleDayFuturePath));
+        String singleDayFutureXml = Files.readString(Paths.get(singleDayFuturePath));
         singleDayFutureXml = singleDayFutureXml.replace("[FUTURE]", LocalDate.now().plusDays(3).format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
 
         String multiCourtPath = "src/test/resources/messages/gateway-message-multi-court.xml";
-        multiCourtXml = Files.readString(Paths.get(multiCourtPath));
+        String multiCourtXml = Files.readString(Paths.get(multiCourtPath));
         multiCourtXml = multiCourtXml.replace("[TODAY]", LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
 
     }
@@ -92,64 +96,54 @@ class MessageProcessorTest {
         JacksonXmlModule xmlModule = new JacksonXmlModule();
         xmlModule.setDefaultUseWrapper(false);
         GatewayMessageParser parser = new GatewayMessageParser(new XmlMapper(xmlModule), validator);
-        messageProcessor = new MessageProcessor(parser, eventBus, matcherService);
+        messageProcessor = new MessageProcessor(parser, eventBus, matcherService, courtCaseService);
         messageProcessor.setCaseFeedFutureDateOffset(3);
     }
 
-    @DisplayName("Receive a valid case then attempt to match")
+    @DisplayName("Receive a valid case which exists then post to the event bus")
     @Test
     void whenValidMessageReceived_ThenAttemptMatch() {
 
+        CourtCase courtCase =  CourtCase.builder().isNew(false).defendantName("NAME").build();
+        when(courtCaseService.getCourtCase(any(Case.class))).thenReturn(Mono.just(courtCase));
+
         messageProcessor.process(singleCaseXml);
 
-        verify(matcherService, timeout(MATCHER_THREAD_TIMEOUT)).match(captor.capture());
-        assertThat(captor.getValue().getCaseNo()).isEqualTo(CASE_NO);
-        assertThat(captor.getValue().getBlock().getSession().getCourtCode()).isEqualTo(COURT_CODE);
+        verify(eventBus, timeout(1000)).post(any(CourtCaseUpdateEvent.class));
     }
 
-    @DisplayName("Receive multiple valid cases then attempt to match")
+    @DisplayName("Receive multiple valid cases then attempt to match one and update two")
     @Test
-    void whenValidMessageReceivedWithMultipleSessions_ThenAttemptMatch() {
+    void givenTwoExistingAndOneNew_whenValidMessageReceivedWithMultipleSessions_ThenAttemptMatchOnOneAndUpdateOnTwo() {
+
+        CaseMatcher case1 = CaseMatcher.builder().caseNo("1600032953").build();
+        CourtCase courtCase1 = CourtCase.builder().isNew(false).caseNo("1600032953").build();
+        CaseMatcher case2 = CaseMatcher.builder().caseNo("1600032979").build();
+        CourtCase courtCase2 = CourtCase.builder().isNew(false).caseNo("1600032979").build();
+        CaseMatcher case3 = CaseMatcher.builder().caseNo("1600032952").build();
+        CourtCase courtCase3 = CourtCase.builder().isNew(true).caseNo("1600032952").build();
+
+        when(courtCaseService.getCourtCase(argThat(case1))).thenReturn(Mono.just(courtCase1));
+        when(courtCaseService.getCourtCase(argThat(case2))).thenReturn(Mono.just(courtCase2));
+        when(courtCaseService.getCourtCase(argThat(case3))).thenReturn(Mono.just(courtCase3));
 
         messageProcessor.process(multiSessionXml);
 
-        verify(matcherService, timeout(MATCHER_THREAD_TIMEOUT).times(3)).match(any(Case.class));
+        verify(eventBus, timeout(1000)).post(argThat(CourtCaseUpdateEventMatcher.builder().caseNo("1600032953").build()));
+        verify(eventBus, timeout(1000)).post(argThat(CourtCaseUpdateEventMatcher.builder().caseNo("1600032979").build()));
+        verify(eventBus, timeout(1000)).post(argThat(CourtCaseMatchEventMatcher.builder().caseNo("1600032952").build()));
     }
 
-    @DisplayName("Receive multiple valid cases then attempt to match")
+    @DisplayName("Receive multiple valid cases then attempt post as updates.")
     @Test
     void whenValidMessageReceivedWithMultipleDays_ThenAttemptMatch() {
+        CourtCase courtCase = mock(CourtCase.class);
+        when(courtCase.isNew()).thenReturn(Boolean.FALSE);
+        when(courtCaseService.getCourtCase(any(Case.class))).thenReturn(Mono.just(courtCase));
 
         messageProcessor.process(multiDayXml);
 
-        verify(matcherService, timeout(MATCHER_THREAD_TIMEOUT).times(6)).match(any(Case.class));
-    }
-
-    @DisplayName("Receive only a single day (document) for cases today. Need to purge for the second date.")
-    @Test
-    void whenValidMessageReceivedWithSingleDay_ThenPurgeForSecondExpected() {
-
-        messageProcessor.process(singleDayXml);
-
-        verify(matcherService, timeout(MATCHER_THREAD_TIMEOUT).times(2)).match(any(Case.class));
-    }
-
-    @DisplayName("Receive only a single day (document) for cases in 3 days time. None for today. We need to purge for today's cases.")
-    @Test
-    void whenValidMessageReceivedWithSingleDayNoCasesToday_ThenPurgeForTodayExpected() {
-
-        messageProcessor.process(singleDayFutureXml);
-
-        verify(matcherService, timeout(MATCHER_THREAD_TIMEOUT).times(1)).match(any(Case.class));
-    }
-
-    @DisplayName("Two courts means two calls to purgeAbsent")
-    @Test
-    void whenValidMessageReceivedWithMultipleCourts_ThenPurgeForBoth() {
-
-        messageProcessor.process(multiCourtXml);
-
-        verify(matcherService, timeout(MATCHER_THREAD_TIMEOUT).times(2)).match(any(Case.class));
+        verify(eventBus, timeout(MATCHER_THREAD_TIMEOUT).times(6)).post(any(CourtCaseUpdateEvent.class));
     }
 
     @DisplayName("An XML message which is invalid")
@@ -183,4 +177,37 @@ class MessageProcessorTest {
         verify(eventBus).post(any(CourtCaseFailureEvent.class));
     }
 
+
+    @Builder
+    public static class CourtCaseUpdateEventMatcher implements ArgumentMatcher<CourtCaseUpdateEvent> {
+
+        private final String caseNo;
+
+        @Override
+        public boolean matches(CourtCaseUpdateEvent otherCase) {
+            return otherCase != null && caseNo.equals(otherCase.getCourtCase().getCaseNo());
+        }
+    }
+
+    @Builder
+    public static class CourtCaseMatchEventMatcher implements ArgumentMatcher<CourtCaseMatchEvent> {
+
+        private final String caseNo;
+
+        @Override
+        public boolean matches(CourtCaseMatchEvent otherCase) {
+            return otherCase != null && caseNo.equals(otherCase.getCourtCase().getCaseNo());
+        }
+    }
+
+    @Builder
+    public static class CaseMatcher implements ArgumentMatcher<Case> {
+
+        private final String caseNo;
+
+        @Override
+        public boolean matches(Case otherCase) {
+            return otherCase != null && caseNo.equals(otherCase.getCaseNo());
+        }
+    }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
@@ -5,12 +5,13 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.MatchIdentifiers;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Offence;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderMatch;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Address;
@@ -22,9 +23,12 @@ import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.I
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.InfoSourceDetail;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Job;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Match;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OtherIds;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,46 +113,83 @@ class CaseMapperTest {
         assertThat(courtCase.getOffences()).isEmpty();
     }
 
-    @DisplayName("Map a new case from gateway case but with no offences")
+    @DisplayName("Map a court case to a new court case when search response has yielded no matches")
     @Test
-    void whenMapNewFromCaseAndOffender_thenCreateNewCaseWithOffenderData() {
+    void givenNoMatches_whenMapNewFromCaseAndSearchResponse_thenCreateNewCaseWithEmptyListOfMatches() {
+        final String crn2 = "X340987";
 
-        ReflectionTestUtils.setField(aCase, "offences", null);
-        GroupedOffenderMatches matches = GroupedOffenderMatches.builder()
-            .matches(singletonList(
-                        OffenderMatch.builder()
-                            .matchType(MatchType.NAME_DOB)
-                            .build()))
+        Match match1 = Match.builder().offender(Offender.builder()
+                                                    .otherIds(OtherIds.builder()
+                                                                        .crn(CRN)
+                                                                        .build())
+                                                    .build())
+                                                .build();
+        Match match2 = Match.builder().offender(Offender.builder().otherIds(OtherIds.builder().crn(crn2).build()).build()).build();
+
+        CourtCase courtCase = caseMapper.newFromCase(aCase);
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matchedBy(OffenderSearchMatchType.ALL_SUPPLIED)
+            .probationStatus("Current")
             .build();
-        CourtCase courtCase = caseMapper.newFromCaseAndOffender(aCase, Offender.builder()
-                .otherIds(OtherIds.builder()
-                        .crn(CRN)
-                        .cro(CRO)
-                        .pnc(PNC)
-                        .build())
-                .build(),
-                DEFAULT_PROBATION_STATUS,
-                matches);
 
-        assertThat(courtCase.getCrn()).isEqualTo(CRN);
-        assertThat(courtCase.getCro()).isEqualTo(CRO);
-        assertThat(courtCase.getPnc()).isEqualTo(PNC);
+        CourtCase courtCaseNew = caseMapper.newFromCourtCaseAndSearchResponse(courtCase, searchResponse);
 
-        assertThat(courtCase.getCaseNo()).isEqualTo("123");
-        assertThat(courtCase.getCaseId()).isEqualTo("321321");
-        assertThat(courtCase.getCourtCode()).isEqualTo(COURT_CODE);
-        assertThat(courtCase.getCourtRoom()).isEqualTo("00");
-        assertThat(courtCase.getProbationStatus()).isEqualTo(DEFAULT_PROBATION_STATUS);
-        assertThat(courtCase.getDefendantAddress().getLine1()).isEqualTo("line 1");
-        assertThat(courtCase.getDefendantAddress().getLine2()).isEqualTo("line 2");
-        assertThat(courtCase.getDefendantAddress().getLine3()).isEqualTo("line 3");
-        assertThat(courtCase.getDefendantAddress().getPostcode()).isEqualTo("LD1 1AA");
-        assertThat(courtCase.getDefendantDob()).isEqualTo(DATE_OF_BIRTH);
-        assertThat(courtCase.getDefendantName()).isEqualTo("Mr James BLUNT");
-        assertThat(courtCase.getDefendantSex()).isEqualTo("M");
-        assertThat(courtCase.getSessionStartTime()).isEqualTo(SESSION_START_TIME);
-        assertThat(courtCase.getOffences()).isEmpty();
-        assertThat(courtCase.getGroupedOffenderMatches().getMatches()).hasSize(1);
+        assertThat(courtCaseNew).isNotSameAs(courtCase);
+        assertThat(courtCaseNew.getCrn()).isNull();
+        assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(0);
+    }
+
+    @DisplayName("Map a court case to a new court case when search response has yielded a single match")
+    @Test
+    void givenSingleMatch_whenMapNewFromCaseAndSearchResponse_thenCreateNewCaseWithEmptyListOfMatches() {
+        Match match = Match.builder().offender(Offender.builder()
+            .otherIds(OtherIds.builder().crn(CRN).cro(CRO).pnc(PNC).build())
+            .build())
+            .build();
+
+        CourtCase courtCase = caseMapper.newFromCase(aCase);
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matchedBy(OffenderSearchMatchType.ALL_SUPPLIED)
+            .matches(List.of(match))
+            .probationStatus("Current")
+            .build();
+
+        CourtCase courtCaseNew = caseMapper.newFromCourtCaseAndSearchResponse(courtCase, searchResponse);
+
+        assertThat(courtCaseNew).isNotSameAs(courtCase);
+        assertThat(courtCaseNew.getCrn()).isEqualTo(CRN);
+        assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(1);
+        OffenderMatch offenderMatch1 = buildOffenderMatch(MatchType.NAME_DOB, CRN, CRO, PNC);
+        assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).containsExactly(offenderMatch1);
+    }
+
+    @DisplayName("Map a court case to a new court case when search response has yielded multiple matches")
+    @Test
+    void givenMultipleMatches_whenMapNewFromCaseAndSearchResponse_thenCreateNewCaseWithEmptyListOfMatches() {
+        Match match1 = Match.builder().offender(Offender.builder()
+            .otherIds(OtherIds.builder().crn(CRN).cro(CRO).pnc(PNC).build())
+            .build())
+            .build();
+        Match match2 = Match.builder().offender(Offender.builder()
+            .otherIds(OtherIds.builder().crn("CRN1").build())
+            .build())
+            .build();
+
+        CourtCase courtCase = caseMapper.newFromCase(aCase);
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matchedBy(OffenderSearchMatchType.PARTIAL_NAME)
+            .matches(List.of(match1, match2))
+            .build();
+
+        CourtCase courtCaseNew = caseMapper.newFromCourtCaseAndSearchResponse(courtCase, searchResponse);
+
+        assertThat(courtCaseNew).isNotSameAs(courtCase);
+        assertThat(courtCaseNew.getCrn()).isNull();
+        assertThat(courtCaseNew.getProbationStatus()).isEqualTo(DEFAULT_PROBATION_STATUS);
+        assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(2);
+        OffenderMatch offenderMatch1 = buildOffenderMatch(MatchType.PARTIAL_NAME, CRN, CRO, PNC);
+        OffenderMatch offenderMatch2 = buildOffenderMatch(MatchType.PARTIAL_NAME, "CRN1", null, null);
+        assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).containsExactlyInAnyOrder(offenderMatch1, offenderMatch2);
     }
 
     @DisplayName("Map from a new case composed of nulls. Ensures no null pointers.")
@@ -262,6 +303,15 @@ class CaseMapperTest {
             .sum("On 02/02/2022 at Town, stole Article, to the value of £0.02, belonging to Person.")
             .title(title)
             .seq(seq)
+            .build();
+    }
+
+    private OffenderMatch buildOffenderMatch(MatchType matchType, String crn, String cro, String pnc) {
+        return OffenderMatch.builder()
+            .matchType(matchType)
+            .confirmed(false)
+            .rejected(false)
+            .matchIdentifiers(MatchIdentifiers.builder().pnc(pnc).cro(cro).crn(crn).build())
             .build();
     }
 

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
@@ -274,7 +274,7 @@ public class CourtCaseRestClientIntTest {
     @Test
     public void whenGetOffenderProbationStatus_thenMakeRestCallToCourtCaseService() {
 
-        Optional<String> optional = restClient.getOffenderProbationStatus("X320741").blockOptional();
+        Optional<String> optional = restClient.getProbationStatus("X320741").blockOptional();
 
         assertThat(optional.get()).isEqualTo("Current");
     }
@@ -282,7 +282,7 @@ public class CourtCaseRestClientIntTest {
     @Test
     public void givenUnknownCrn_whenGetOffenderProbationStatus_thenMakeReturnEmpty() {
 
-        String optional = restClient.getOffenderProbationStatus("X500").block();
+        String optional = restClient.getProbationStatus("X500").block();
 
         assertThat(optional).isNull();
     }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
@@ -284,6 +284,6 @@ public class CourtCaseRestClientIntTest {
 
         String optional = restClient.getProbationStatus("X500").block();
 
-        assertThat(optional).isNull();
+        assertThat(optional).isEmpty();
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseServiceTest.java
@@ -12,19 +12,31 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Block;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
+import uk.gov.justice.probation.courtcasematcher.model.mapper.CaseMapper;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 import uk.gov.justice.probation.courtcasematcher.restclient.CourtCaseRestClient;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CourtCaseServiceTest {
 
     private static final LocalDate JAN_1 = LocalDate.of(2020, Month.JANUARY, 1);
     private static final LocalDate JAN_3 = LocalDate.of(2020, Month.JANUARY, 3);
+    private static final String COURT_CODE = "B10JQ00";
+    private static final String CASE_NO = "1234567890";
+    private static final Long CASE_ID = 321344L;
+
+    @Mock
+    private CaseMapper caseMapper;
 
     @Mock
     private CourtCaseRestClient restClient;
@@ -36,11 +48,11 @@ class CourtCaseServiceTest {
     @Test
     void purgeAbsent() {
 
-        Session sessionJan1a = Session.builder().dateOfHearing(JAN_1).courtCode("SHF").build();
-        Session sessionJan1b = Session.builder().dateOfHearing(JAN_1).courtCode("SHF").build();
+        Session sessionJan1a = Session.builder().dateOfHearing(JAN_1).courtCode(COURT_CODE).build();
+        Session sessionJan1b = Session.builder().dateOfHearing(JAN_1).courtCode(COURT_CODE).build();
 
-        Session sessionJan3a = Session.builder().dateOfHearing(JAN_3).courtCode("SHF").build();
-        Session sessionJan3b = Session.builder().dateOfHearing(JAN_3).courtCode("SHF").build();
+        Session sessionJan3a = Session.builder().dateOfHearing(JAN_3).courtCode(COURT_CODE).build();
+        Session sessionJan3b = Session.builder().dateOfHearing(JAN_3).courtCode(COURT_CODE).build();
 
         Case aCase10 = Case.builder().caseNo("1010").block(Block.builder().session(sessionJan1a).build()).build();
         Case aCase20 = Case.builder().caseNo("1011").block(Block.builder().session(sessionJan1b).build()).build();
@@ -50,10 +62,10 @@ class CourtCaseServiceTest {
 
         List<Case> allCases = asList(aCase20, aCase21, aCase10, aCase30, aCase31);
 
-        courtCaseService.purgeAbsent("SHF", Set.of(JAN_1, JAN_3), allCases);
+        courtCaseService.purgeAbsent(COURT_CODE, Set.of(JAN_1, JAN_3), allCases);
 
         Map<LocalDate, List<String>> expected = Map.of(JAN_1, asList("1010", "1011"), JAN_3, asList("1030", "1031", "1032"));
-        verify(restClient).purgeAbsent("SHF", expected);
+        verify(restClient).purgeAbsent(COURT_CODE, expected);
     }
 
     @DisplayName("Purge with 2 cases across 1 sessions and 2 days. One day has no cases.")
@@ -61,14 +73,98 @@ class CourtCaseServiceTest {
     void purgeAbsentNoCases() {
 
 
-        Session sessionJan3 = Session.builder().dateOfHearing(JAN_3).courtCode("SHF").build();
+        Session sessionJan3 = Session.builder().dateOfHearing(JAN_3).courtCode(COURT_CODE).build();
 
         Case aCase30 = Case.builder().caseNo("1031").block(Block.builder().session(sessionJan3).build()).build();
         Case aCase31 = Case.builder().caseNo("1032").block(Block.builder().session(sessionJan3).build()).build();
 
-        courtCaseService.purgeAbsent("SHF", Set.of(JAN_1, JAN_3), asList(aCase30, aCase31));
+        courtCaseService.purgeAbsent(COURT_CODE, Set.of(JAN_1, JAN_3), asList(aCase30, aCase31));
 
         Map<LocalDate, List<String>> expected = Map.of(JAN_1, Collections.emptyList(), JAN_3, asList("1031", "1032"));
-        verify(restClient).purgeAbsent("SHF", expected);
+        verify(restClient).purgeAbsent(COURT_CODE, expected);
+    }
+
+    @DisplayName("Save court case.")
+    @Test
+    void saveCourtCase() {
+
+        CourtCase courtCase = CourtCase.builder().caseNo(CASE_NO).courtCode(COURT_CODE).build();
+
+        courtCaseService.saveCourtCase(courtCase);
+
+        verify(restClient).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+    }
+
+    @DisplayName("Get court case which is also merged with the existing.")
+    @Test
+    void givenExistingCase_whenGetCourtCase_thenMergeAndReturn() {
+        Case aCase = buildCase();
+
+        CourtCase courtCase = CourtCase.builder().caseId(Long.toString(CASE_ID)).caseNo(CASE_NO).courtCode(COURT_CODE).build();
+        when(restClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.just(courtCase));
+        when(caseMapper.merge(aCase, courtCase)).thenReturn(courtCase);
+
+        CourtCase courtCase1 = courtCaseService.getCourtCase(aCase).block();
+
+        assertThat(courtCase1).isSameAs(courtCase);
+        verify(restClient).getCourtCase(COURT_CODE, CASE_NO);
+        verify(caseMapper).merge(aCase, courtCase);
+    }
+
+    @DisplayName("Get court case which is new, return a transformed copy.")
+    @Test
+    void givenNewCase_whenGetCourtCase_thenReturn() {
+        Case aCase = buildCase();
+
+        CourtCase courtCase = CourtCase.builder().caseId(Long.toString(CASE_ID)).caseNo(CASE_NO).courtCode(COURT_CODE).build();
+        when(restClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
+        when(caseMapper.newFromCase(aCase)).thenReturn(courtCase);
+
+        CourtCase courtCase1 = courtCaseService.getCourtCase(aCase).block();
+
+        assertThat(courtCase1).isSameAs(courtCase);
+        verify(restClient).getCourtCase(COURT_CODE, CASE_NO);
+        verify(caseMapper).newFromCase(aCase);
+    }
+
+    @DisplayName("Save a court case with a search response.")
+    @Test
+    void givenSearchResponse_whenCreateCourtCase_thenPutCase() {
+
+        SearchResponse searchResponse = SearchResponse.builder().build();
+        CourtCase courtCase = CourtCase.builder().caseId(Long.toString(CASE_ID)).caseNo(CASE_NO).courtCode(COURT_CODE).build();
+        when(caseMapper.newFromCourtCaseAndSearchResponse(courtCase, searchResponse)).thenReturn(courtCase);
+
+        courtCaseService.createCase(courtCase, searchResponse);
+
+        verify(restClient).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+        verify(caseMapper).newFromCourtCaseAndSearchResponse(courtCase, searchResponse);
+    }
+
+    @DisplayName("Save a court case without a search response.")
+    @Test
+    void givenNoSearchResponse_whenCreateCourtCase_thenReturn() {
+
+        CourtCase courtCase = CourtCase.builder().caseId(Long.toString(CASE_ID)).caseNo(CASE_NO).courtCode(COURT_CODE).build();
+
+        courtCaseService.createCase(courtCase, null);
+
+        verify(restClient).putCourtCase(COURT_CODE, CASE_NO, courtCase);
+    }
+
+    private Case buildCase() {
+        Session session = Session.builder()
+            .courtCode(COURT_CODE)
+            .build();
+
+        Block block = Block.builder()
+            .session(session)
+            .build();
+
+        return Case.builder()
+            .block(block)
+            .caseNo(CASE_NO)
+            .id(CASE_ID)
+            .build();
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -2,11 +2,6 @@ package uk.gov.justice.probation.courtcasematcher.service;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -30,18 +25,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.MatchIdentifiers;
-import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.OffenderMatch;
-import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Block;
-import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Case;
-import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Session;
-import uk.gov.justice.probation.courtcasematcher.model.mapper.CaseMapper;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Match;
-import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OtherIds;
@@ -55,25 +40,16 @@ class MatcherServiceTest {
     private static final String CASE_NO = "1600032952";
     private static final long REST_CLIENT_WAIT_MS = 2000;
     private static final String CRN = "X123456";
-    private static final String DEFAULT_PROBATION_STATUS = "Not known";
+    private static final String PROBATION_STATUS = "Current";
 
     private final LocalDate DEF_DOB = LocalDate.of(2000, 6, 17);
     private final String DEF_NAME = "Arthur MORGAN";
-
-    @Mock
-    private Session session;
-
-    private Case incomingCase;
 
     private final OtherIds otherIds = OtherIds.builder()
         .crn(CRN)
         .cro("CRO")
         .pnc("PNC")
         .build();
-    private final CourtCase courtCase = CourtCase.builder()
-            .caseNo(CASE_NO)
-            .courtCode(COURT_CODE)
-            .build();
     private final Offender offender = Offender.builder()
             .otherIds(otherIds)
             .build();
@@ -97,33 +73,9 @@ class MatcherServiceTest {
             .matchedBy(OffenderSearchMatchType.NOTHING)
             .matches(Collections.emptyList())
             .build();
-    private final SearchResponse singleFuzzyMatch = SearchResponse.builder()
-            .matches(singletonList(Match.builder()
-                    .offender(offender)
-                    .build()))
-            .matchedBy(OffenderSearchMatchType.PARTIAL_NAME_DOB_LENIENT)
-            .build();
-
-    private final OffenderMatch offenderMatch = OffenderMatch.builder()
-        .matchType(MatchType.NAME_DOB)
-        .confirmed(false)
-        .rejected(false)
-        .matchIdentifiers(MatchIdentifiers.builder()
-            .crn(CRN)
-            .cro("CRO")
-            .pnc("PNC")
-            .build())
-        .build();
-
-    private final GroupedOffenderMatches groupedOffenderMatches = GroupedOffenderMatches.builder()
-        .matches(singletonList(offenderMatch))
-        .build();
 
     @Mock
     private CourtCaseRestClient courtCaseRestClient;
-
-    @Mock
-    private CaseMapper caseMapper;
 
     @Mock
     private OffenderSearchRestClient offenderSearchRestClient;
@@ -141,156 +93,58 @@ class MatcherServiceTest {
         Logger logger = (Logger) getLogger(LoggerFactory.getLogger(MatcherService.class).getName());
         logger.addAppender(mockAppender);
 
-        incomingCase = Case.builder()
-            .caseNo(CASE_NO)
-            .def_dob(DEF_DOB)
-            .def_name(DEF_NAME)
-            .block(Block.builder()
-                .session(session)
-                .build())
-            .build();
-
-        when(session.getCourtCode()).thenReturn(COURT_CODE);
-
-        matcherService = new MatcherService(courtCaseRestClient, offenderSearchRestClient, caseMapper);
+        matcherService = new MatcherService(courtCaseRestClient, offenderSearchRestClient);
     }
 
     @Test
-    public void givenIncomingCaseMatchesExisting_whenMatchCalled_thenMergeAndStore() {
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.just(courtCase));
-        when(caseMapper.merge(incomingCase, courtCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
-
-        matcherService.match(incomingCase);
-
-        verify(caseMapper).merge(incomingCase, courtCase);
-        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(String.class), any(GroupedOffenderMatches.class));
-        verify(caseMapper, never()).newFromCase(incomingCase);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verify(courtCaseRestClient, never()).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
-    }
-
-    @Test
-    void givenIncomingCaseDoesNotMatchExistingCase_andItDoesNotMatchAnOffender_whenMatchCalled_thenCreateANewRecord(){
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
+    void givenIncomingDefendantDoesNotMatchAnOffender_whenMatchCalled_thenLog(){
         when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.empty());
-        when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
 
-        matcherService.match(incomingCase);
+        SearchResponse searchResponse = matcherService.getSearchResponse(DEF_NAME, DEF_DOB, COURT_CODE, CASE_NO).block();
 
-        verify(caseMapper).newFromCase(incomingCase);
-        verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(String.class), any(GroupedOffenderMatches.class));
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verify(courtCaseRestClient, never()).postMatches(COURT_CODE, CASE_NO, groupedOffenderMatches);
-    }
-
-    @Test
-    void givenIncomingCaseDoesNotMatchExistingCase_andItExactlyMatchesASingleOffender_whenMatchCalled_thenCreateANewRecordWithOffenderData(){
-
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
-        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleExactMatch));
-        when(courtCaseRestClient.getOffenderProbationStatus(CRN)).thenReturn(Mono.just("Previously known"));
-        when(caseMapper.newFromCaseAndOffender(incomingCase, offender, "Previously known", groupedOffenderMatches)).thenReturn(courtCase);
-
-        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
-
-        matcherService.match(incomingCase);
-
-        verify(caseMapper).newFromCaseAndOffender(incomingCase, offender, "Previously known", groupedOffenderMatches);
-        verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCase(incomingCase);
-        verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
-        verify(courtCaseRestClient).getOffenderProbationStatus(CRN);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verifyNoMoreInteractions(courtCaseRestClient);
-    }
-
-    @Test
-    void givenIncomingCaseDoesNotMatchExistingCase_andItExactlyMatchesAMultipleOffenders_whenMatchCalled_thenCreateANewRecordWithoutOffenderData(){
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
-        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(multipleExactMatches));
-        when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
-
-        matcherService.match(incomingCase);
-
-        verify(caseMapper).newFromCase(incomingCase);
-        verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(String.class), any(GroupedOffenderMatches.class));
-        verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verifyNoMoreInteractions(courtCaseRestClient);
-    }
-
-    @Test
-    void givenIncomingCaseDoesNotMatchExistingCase_andItHasNoExactMatches_whenMatchCalled_thenCreateANewRecordWithoutOffenderData(){
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
-        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(noMatches));
-        when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
-
-        matcherService.match(incomingCase);
-
-        verify(caseMapper).newFromCase(incomingCase);
-        verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(String.class), any(GroupedOffenderMatches.class));
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verifyNoMoreInteractions(courtCaseRestClient);
-    }
-
-    @Test
-    void givenIncomingCaseDoesNotMatchExistingCase_andItHasOnePartialMatch_whenMatchCalled_thenCreateANewRecordWithoutOffenderData(){
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
-        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleFuzzyMatch));
-        when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(eq(COURT_CODE), eq(CASE_NO), eq(courtCase))).thenReturn(mock(Disposable.class));
-
-        matcherService.match(incomingCase);
-
-        verify(caseMapper).newFromCase(incomingCase);
-        verify(caseMapper, never()).merge(any(Case.class), eq(courtCase));
-        verify(caseMapper, never()).newFromCaseAndOffender(eq(incomingCase), eq(offender), any(String.class), any(GroupedOffenderMatches.class));
-        verify(courtCaseRestClient, timeout(REST_CLIENT_WAIT_MS)).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verifyNoMoreInteractions(courtCaseRestClient);
-    }
-
-    @Test
-    public void whenMatchesReturned_thenPostMatchesAndLogTheDetails() {
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
-        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleExactMatch));
-        when(courtCaseRestClient.getOffenderProbationStatus(CRN)).thenReturn(Mono.just("Current"));
-        when(caseMapper.newFromCaseAndOffender(eq(incomingCase), any(Offender.class), eq("Current"), any(GroupedOffenderMatches.class))).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
-
-        matcherService.match(incomingCase);
-
-        LoggingEvent loggingEvent = captureFirstLogEvent();
-        assertThat(loggingEvent.getLevel()).isEqualTo(Level.INFO);
-        assertThat(loggingEvent.getFormattedMessage().trim())
-                .contains("Match results for caseNo: 1600032952, courtCode: SHF - matchedBy: ALL_SUPPLIED, matchCount: 1");
-
-        verify(courtCaseRestClient).getCourtCase(COURT_CODE, CASE_NO);
-        verify(courtCaseRestClient).getOffenderProbationStatus(CRN);
-        verify(courtCaseRestClient).putCourtCase(COURT_CODE, CASE_NO, courtCase);
-        verifyNoMoreInteractions(courtCaseRestClient);
-    }
-
-    @Test
-    void whenEmptyMonoReturned_thenLogDetails(){
-        when(courtCaseRestClient.getCourtCase(COURT_CODE, CASE_NO)).thenReturn(Mono.empty());
-        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.empty());
-        when(caseMapper.newFromCase(incomingCase)).thenReturn(courtCase);
-        when(courtCaseRestClient.putCourtCase(COURT_CODE, CASE_NO, courtCase)).thenReturn(mock(Disposable.class));
-
-        matcherService.match(incomingCase);
-
+        assertThat(searchResponse).isNull();
         LoggingEvent loggingEvent = captureFirstLogEvent();
         assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR);
         assertThat(loggingEvent.getFormattedMessage().trim())
-                .contains("Match results for caseNo: 1600032952, courtCode: SHF - Empty response from OffenderSearchRestClient");
+            .contains("Match results for caseNo: 1600032952, courtCode: SHF - Empty response from OffenderSearchRestClient");
         verifyNoMoreInteractions(courtCaseRestClient);
+    }
+
+    @Test
+    void givenMatchesToMultipleOffenders_whenMatchCalled_thenReturn(){
+        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(multipleExactMatches));
+
+        SearchResponse searchResponse = matcherService.getSearchResponse(DEF_NAME, DEF_DOB, COURT_CODE, CASE_NO).block();
+
+        assertThat(searchResponse.getMatches()).hasSize(2);
+        assertThat(searchResponse.getMatchedBy()).isSameAs(OffenderSearchMatchType.ALL_SUPPLIED);
+        assertThat(searchResponse.getProbationStatus()).isNull();
+    }
+
+    @Test
+    void givenMatchesToSingleOffender_whenSearchResponse_thenReturnWithProbationStatus(){
+
+        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(singleExactMatch));
+        when(courtCaseRestClient.getProbationStatus(CRN)).thenReturn(Mono.just(PROBATION_STATUS));
+
+        SearchResponse searchResponse = matcherService.getSearchResponse(DEF_NAME, DEF_DOB, COURT_CODE, CASE_NO).block();
+
+        assertThat(searchResponse.getMatches()).hasSize(1);
+        assertThat(searchResponse.getMatchedBy()).isSameAs(OffenderSearchMatchType.ALL_SUPPLIED);
+        assertThat(searchResponse.getProbationStatus()).isEqualTo(PROBATION_STATUS);
+    }
+
+    @Test
+    void givenZeroMatches_whenSearchResponse_thenReturn(){
+
+        when(offenderSearchRestClient.search(DEF_NAME, DEF_DOB)).thenReturn(Mono.just(noMatches));
+
+        SearchResponse searchResponse = matcherService.getSearchResponse(DEF_NAME, DEF_DOB, COURT_CODE, CASE_NO).block();
+
+        assertThat(searchResponse.getMatches()).hasSize(0);
+        assertThat(searchResponse.getMatchedBy()).isSameAs(OffenderSearchMatchType.NOTHING);
+        assertThat(searchResponse.getProbationStatus()).isNull();
+
     }
 
     private LoggingEvent captureFirstLogEvent() {

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -38,7 +38,6 @@ import uk.gov.justice.probation.courtcasematcher.restclient.OffenderSearchRestCl
 class MatcherServiceTest {
     private static final String COURT_CODE = "SHF";
     private static final String CASE_NO = "1600032952";
-    private static final long REST_CLIENT_WAIT_MS = 2000;
     private static final String CRN = "X123456";
     private static final String PROBATION_STATUS = "Current";
 
@@ -144,7 +143,6 @@ class MatcherServiceTest {
         assertThat(searchResponse.getMatches()).hasSize(0);
         assertThat(searchResponse.getMatchedBy()).isSameAs(OffenderSearchMatchType.NOTHING);
         assertThat(searchResponse.getProbationStatus()).isNull();
-
     }
 
     private LoggingEvent captureFirstLogEvent() {

--- a/src/test/resources/messages/gateway-message-multi-session.xml
+++ b/src/test/resources/messages/gateway-message-multi-session.xml
@@ -57,7 +57,7 @@
                                                         <c_id>1217464</c_id>
                                                         <h_id>1293277</h_id>
                                                         <valid>Y</valid>
-                                                        <caseno>1600032952</caseno>
+                                                        <caseno>1600032953</caseno>
                                                         <type>C</type>
                                                         <prov>N</prov>
                                                         <urn>PROSECUTOR URN</urn>


### PR DESCRIPTION
Two main things 

1. Support for > 1 match in the match
2. Refactoring of the service. This has a few strands
> Reduce code complexity in MatcherService. This now just returns a SearchResponse and does not deal with saving / merging cases.
> Access to WebClient is behind the services.
> Initiation of save / update / match happens from the Event Listener / Event Bus setup. MessageProcessor now just unpacks the message, and posts events to the EventBus on a case by case basis, so also has fewer responsibilities.