### PR TITLE
🐛 Store "Possible nDelius record" when initial match process gives > 1 match

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
@@ -28,7 +28,7 @@ public class CaseMapper {
 
     private final String defaultProbationStatus;
 
-    public CaseMapper(@Value("${case-mapper-reference.defaultProbationStatus}") String defaultProbationStatus) {
+    public CaseMapper(@Value("${probation-status-reference.default}") String defaultProbationStatus) {
         super();
         this.defaultProbationStatus = defaultProbationStatus;
     }
@@ -40,7 +40,7 @@ public class CaseMapper {
             .build();
     }
 
-    private CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(CourtCase courtCase) {
+    private CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(CourtCase courtCase, String probationStatus) {
         return CourtCase.builder()
             .caseNo(courtCase.getCaseNo())
             .courtCode(courtCase.getCourtCode())
@@ -54,7 +54,7 @@ public class CaseMapper {
             .pnc(courtCase.getPnc())
             .listNo(courtCase.getListNo())
             .sessionStartTime(courtCase.getSessionStartTime())
-            .probationStatus(defaultProbationStatus)
+            .probationStatus(Optional.ofNullable(probationStatus).orElse(defaultProbationStatus))
             .nationality1(courtCase.getNationality1())
             .nationality2(courtCase.getNationality2())
             .offences(courtCase.getOffences());
@@ -137,7 +137,7 @@ public class CaseMapper {
 
         CourtCaseBuilder courtCaseBuilder;
 
-        courtCaseBuilder = getCourtCaseBuilderFromCase(incomingCase)
+        courtCaseBuilder = getCourtCaseBuilderFromCase(incomingCase, searchResponse.getProbationStatus())
             .groupedOffenderMatches(buildGroupedOffenderMatch(searchResponse.getMatches(), matchType));
 
         if (matches.size() == 1) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,8 +66,9 @@ web:
     read-timeout-ms: 5000
     write-timeout-ms: 5000
 
-case-mapper-reference:
-  defaultProbationStatus: "No record"
+probation-status-reference:
+  default: "No record"
+  multiMatch: "Possible nDelius record"
 
 # Libra feed has today's case list and another case list for this many days hence. e.g. 25th and 28th July
 case-feed-future-date-offset: 3

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CaseMapperTest {
 
     private static final String DEFAULT_PROBATION_STATUS = "No record";
+    private static final String MATCHES_PROBATION_STATUS = "Possible nDelius record";
     private static final LocalDate DATE_OF_BIRTH = LocalDate.of(1969, Month.AUGUST, 26);
     private static final LocalDate DATE_OF_HEARING = LocalDate.of(2020, Month.FEBRUARY, 29);
     private static final LocalTime START_TIME = LocalTime.of(9, 10);
@@ -193,6 +194,7 @@ class CaseMapperTest {
         CourtCase courtCase = caseMapper.newFromCase(aCase);
         SearchResponse searchResponse = SearchResponse.builder()
             .matchedBy(OffenderSearchMatchType.PARTIAL_NAME)
+            .probationStatus(MATCHES_PROBATION_STATUS)
             .matches(List.of(match1, match2))
             .build();
 
@@ -200,7 +202,7 @@ class CaseMapperTest {
 
         assertThat(courtCaseNew).isNotSameAs(courtCase);
         assertThat(courtCaseNew.getCrn()).isNull();
-        assertThat(courtCaseNew.getProbationStatus()).isEqualTo(DEFAULT_PROBATION_STATUS);
+        assertThat(courtCaseNew.getProbationStatus()).isEqualTo(MATCHES_PROBATION_STATUS);
         assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(2);
         OffenderMatch offenderMatch1 = buildOffenderMatch(MatchType.PARTIAL_NAME, CRN, CRO, PNC);
         OffenderMatch offenderMatch2 = buildOffenderMatch(MatchType.PARTIAL_NAME, "CRN1", null, null);

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -40,6 +40,8 @@ class MatcherServiceTest {
     private static final String CASE_NO = "1600032952";
     private static final String CRN = "X123456";
     private static final String PROBATION_STATUS = "Current";
+    private static final String DEFAULT_PROBATION_STATUS = "No record";
+    private static final String MATCHES_PROBATION_STATUS = "Possible nDelius record";
 
     private final LocalDate DEF_DOB = LocalDate.of(2000, 6, 17);
     private final String DEF_NAME = "Arthur MORGAN";
@@ -92,7 +94,7 @@ class MatcherServiceTest {
         Logger logger = (Logger) getLogger(LoggerFactory.getLogger(MatcherService.class).getName());
         logger.addAppender(mockAppender);
 
-        matcherService = new MatcherService(courtCaseRestClient, offenderSearchRestClient);
+        matcherService = new MatcherService(courtCaseRestClient, offenderSearchRestClient, DEFAULT_PROBATION_STATUS, MATCHES_PROBATION_STATUS);
     }
 
     @Test
@@ -117,7 +119,7 @@ class MatcherServiceTest {
 
         assertThat(searchResponse.getMatches()).hasSize(2);
         assertThat(searchResponse.getMatchedBy()).isSameAs(OffenderSearchMatchType.ALL_SUPPLIED);
-        assertThat(searchResponse.getProbationStatus()).isNull();
+        assertThat(searchResponse.getProbationStatus()).isEqualTo(MATCHES_PROBATION_STATUS);
     }
 
     @Test
@@ -142,7 +144,7 @@ class MatcherServiceTest {
 
         assertThat(searchResponse.getMatches()).hasSize(0);
         assertThat(searchResponse.getMatchedBy()).isSameAs(OffenderSearchMatchType.NOTHING);
-        assertThat(searchResponse.getProbationStatus()).isNull();
+        assertThat(searchResponse.getProbationStatus()).isEqualTo(DEFAULT_PROBATION_STATUS);
     }
 
     private LoggingEvent captureFirstLogEvent() {


### PR DESCRIPTION
Matcher used to apply a default status when 0 or > 1 match was found. Change so that > 1 match gives "Possible nDelius record" as the status 