### PR TITLE
🐛 Proper handling of partial / single match

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
@@ -132,15 +132,12 @@ public class CaseMapper {
 
     public CourtCase newFromCourtCaseAndSearchResponse(CourtCase incomingCase, SearchResponse searchResponse) {
 
-        List<Match> matches = searchResponse.getMatches() != null ? searchResponse.getMatches() : Collections.emptyList();
         MatchType matchType = MatchType.of(searchResponse.getMatchedBy());
 
-        CourtCaseBuilder courtCaseBuilder;
-
-        courtCaseBuilder = getCourtCaseBuilderFromCase(incomingCase, searchResponse.getProbationStatus())
+        CourtCaseBuilder courtCaseBuilder = getCourtCaseBuilderFromCase(incomingCase, searchResponse.getProbationStatus())
             .groupedOffenderMatches(buildGroupedOffenderMatch(searchResponse.getMatches(), matchType));
 
-        if (matches.size() == 1) {
+        if (searchResponse.isExactMatch()) {
             Match match = searchResponse.getMatches().get(0);
             courtCaseBuilder
                 .probationStatus(Optional.ofNullable(searchResponse.getProbationStatus()).orElse(defaultProbationStatus))

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponse.java
@@ -1,8 +1,14 @@
 package uk.gov.justice.probation.courtcasematcher.model.offendersearch;
 
-import lombok.*;
-
 import java.util.List;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Builder
 @Data
@@ -13,4 +19,10 @@ public class SearchResponse {
     private final List<Match> matches;
     private final OffenderSearchMatchType matchedBy;
     private final String probationStatus;
+
+    @JsonIgnore
+    public boolean isExactMatch() {
+        int matchCount = Optional.ofNullable(matches).map(List::size).orElse(0);
+        return matchCount == 1 && matchedBy == OffenderSearchMatchType.ALL_SUPPLIED;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,7 @@ web:
 
 probation-status-reference:
   default: "No record"
-  multiMatch: "Possible nDelius record"
+  nonExactMatch: "Possible nDelius record"
 
 # Libra feed has today's case list and another case list for this many days hence. e.g. 25th and 28th July
 case-feed-future-date-offset: 3

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
@@ -155,6 +155,31 @@ class CaseMapperTest {
         assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).containsExactly(offenderMatch1);
     }
 
+    @DisplayName("Map a court case to a new court case when search response has yielded a single match")
+    @Test
+    void givenSingleMatchOnName_whenMapNewFromCaseAndSearchResponse_thenCreateNewCaseWithSingleMatchButNoCrn() {
+        Match match = Match.builder().offender(Offender.builder()
+            .otherIds(OtherIds.builder().crn(CRN).cro(CRO).pnc(PNC).build())
+            .build())
+            .build();
+
+        CourtCase courtCase = caseMapper.newFromCase(aCase);
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matchedBy(OffenderSearchMatchType.NAME)
+            .matches(List.of(match))
+            .probationStatus(MATCHES_PROBATION_STATUS)
+            .build();
+
+        CourtCase courtCaseNew = caseMapper.newFromCourtCaseAndSearchResponse(courtCase, searchResponse);
+
+        assertThat(courtCaseNew).isNotSameAs(courtCase);
+        assertThat(courtCaseNew.getCrn()).isNull();
+        assertThat(courtCaseNew.getProbationStatus()).isEqualTo(MATCHES_PROBATION_STATUS);
+        assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(1);
+        OffenderMatch expectedOffenderMatch = buildOffenderMatch(MatchType.NAME, CRN, CRO, PNC);
+        assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).containsExactly(expectedOffenderMatch);
+    }
+
     @DisplayName("Map a court case to a new court case when search response has yielded a single match but null probation status")
     @Test
     void givenSingleMatchWithNoProbationStatus_whenMapNewFromCaseAndSearchResponse_thenCreateNewCaseWithSingleMatch() {

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponseTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/offendersearch/SearchResponseTest.java
@@ -1,0 +1,65 @@
+package uk.gov.justice.probation.courtcasematcher.model.offendersearch;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DisplayName("SearchResponse is component to receive")
+class SearchResponseTest {
+
+    private final Match match = Match.builder().offender(Offender.builder().build()).build();
+
+    @DisplayName("Search with one match for ALL_SUPPLIED is exact")
+    @Test
+    void givenSingleMatchAllSupplied_whenIsExact_thenReturnTrue() {
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matches(List.of(match))
+            .matchedBy(OffenderSearchMatchType.ALL_SUPPLIED)
+            .build();
+
+        assertThat(searchResponse.isExactMatch()).isTrue();
+    }
+
+    @DisplayName("Search with one match for anything but ALL_SUPPLIED is NOT exact")
+    @Test
+    void givenSingleMatchPartialOrName_whenIsExact_thenReturnFalse() {
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matches(List.of(match))
+            .matchedBy(OffenderSearchMatchType.PARTIAL_NAME)
+            .build();
+
+        assertThat(searchResponse.isExactMatch()).isFalse();
+    }
+
+    @DisplayName("Search with multiple matches is always NOT exact")
+    @Test
+    void givenMultipleMatches_whenIsExact_thenAlwaysReturnFalse() {
+        Match match2 = Match.builder().offender(Offender.builder().build()).build();
+
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matches(List.of(match, match2))
+            .matchedBy(OffenderSearchMatchType.ALL_SUPPLIED)
+            .build();
+
+        assertThat(searchResponse.isExactMatch()).isFalse();
+    }
+
+    @DisplayName("Search with no matches is always NOT exact")
+    @Test
+    void givenZeroMatches_whenIsExact_thenAlwaysReturnFalse() {
+        SearchResponse searchResponse = SearchResponse.builder()
+            .matchedBy(OffenderSearchMatchType.NOTHING)
+            .build();
+
+        assertThat(searchResponse.isExactMatch()).isFalse();
+
+        searchResponse = SearchResponse.builder()
+            .matchedBy(OffenderSearchMatchType.ALL_SUPPLIED)
+            .build();
+
+        assertThat(searchResponse.isExactMatch()).isFalse();
+    }
+}

--- a/src/test/resources/mocks/__files/offender-search/POST_search_single_nonexact_response.json
+++ b/src/test/resources/mocks/__files/offender-search/POST_search_single_nonexact_response.json
@@ -1,0 +1,68 @@
+{
+  "matches": [
+    {
+      "offender": {
+        "offenderId": 2500371167,
+        "title": "Mr",
+        "firstName": "Calvin",
+        "surname": "HARRIS",
+        "dateOfBirth": "1969-08-26",
+        "gender": "Male",
+        "otherIds": {
+          "crn": "X346204",
+          "cro": "1234ABC",
+          "pnc": "ABCD1234"
+        },
+        "contactDetails": {},
+        "offenderProfile": {
+          "offenderLanguages": {},
+          "previousConviction": {}
+        },
+        "offenderManagers": [
+          {
+            "trustOfficer": {
+              "forenames": "Unallocated Staff(N07)",
+              "surname": "Staff"
+            },
+            "staff": {
+              "forenames": "Unallocated Staff(N07)",
+              "surname": "Staff"
+            },
+            "partitionArea": "National Data",
+            "softDeleted": false,
+            "team": {
+              "description": "Unallocated Team(N07)",
+              "district": {
+                "code": "N07NPSA",
+                "description": "N07 Division"
+              },
+              "borough": {
+                "code": "N07100",
+                "description": "N07 Cluster 1"
+              }
+            },
+            "probationArea": {
+              "code": "N07",
+              "description": "NPS London",
+              "nps": true
+            },
+            "fromDate": "1900-01-01",
+            "active": true,
+            "allocationReason": {
+              "code": "IN1",
+              "description": "Initial Allocation"
+            }
+          }
+        ],
+        "softDeleted": false,
+        "currentDisposal": "1",
+        "partitionArea": "National Data",
+        "currentRestriction": false,
+        "restrictionMessage": "This is a restricted offender record. Please contact a system administrator",
+        "currentExclusion": false,
+        "exclusionMessage": "You are excluded from viewing this offender record. Please contact a system administrator"
+      }
+    }
+  ],
+  "matchedBy": "NAME"
+}

--- a/src/test/resources/mocks/mappings/offender-search/POST_search_with_single_nonexact_match.json
+++ b/src/test/resources/mocks/mappings/offender-search/POST_search_with_single_nonexact_match.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/match",
+    "bodyPatterns" : [
+      {
+        "equalToJson" : {
+          "firstName": "calvin",
+          "surname": "harris",
+          "dateOfBirth": "1969-08-26"
+        }
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "offender-search/POST_search_single_nonexact_response.json"
+  }
+}


### PR DESCRIPTION
Single matches with PARTIAL_NAME were being regarded as successful. 