### PR TITLE
✨ PIC-822 retry mechanism for offender search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,21 +75,24 @@ dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     runtimeOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
-    compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
     implementation 'org.springframework.boot:spring-boot-starter-artemis'
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 
-    compile 'org.springframework.boot:spring-boot-starter-webflux'
-    compile 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
+
     implementation 'com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.2'
     implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.2'
     implementation 'net.logstash.logback:logstash-logback-encoder:6.4'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-oauth2-client'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.security:spring-security-oauth2-client'
+    testImplementation 'io.projectreactor:reactor-test'
+
     testImplementation 'net.javacrumbs.json-unit:json-unit-assertj:2.19.0'
     testImplementation 'org.assertj:assertj-core:3.17.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.7.0'

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/event/OffenderSearchFailureEvent.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/event/OffenderSearchFailureEvent.java
@@ -3,11 +3,12 @@ package uk.gov.justice.probation.courtcasematcher.event;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 
 @AllArgsConstructor
 @Getter
 @Builder
 public class OffenderSearchFailureEvent {
-    private final String requestJson;
     private final String failureMessage;
+    private final CourtCase courtCase;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClient.java
@@ -1,51 +1,59 @@
 package uk.gov.justice.probation.courtcasematcher.restclient;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.eventbus.EventBus;
+import java.util.function.Predicate;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.util.StringUtils;
-import uk.gov.justice.probation.courtcasematcher.event.OffenderSearchFailureEvent;
+import reactor.util.retry.Retry;
+import reactor.util.retry.Retry.RetrySignal;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Name;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchRequest;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
 
 import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;
 
-@SuppressWarnings("UnstableApiUsage")
 @Component
 @Slf4j
 public class OffenderSearchRestClient {
     private static final String ERROR_NO_DATE_OF_BIRTH = "No dateOfBirth provided";
     private static final String ERROR_NO_NAME = "No surname provided";
+
+    @Setter
     @Value("${offender-search.post-match-url}")
     private String postMatchUrl;
 
+    @Setter
     @Value("${offender-search.disable-authentication:false}")
     private Boolean disableAuthentication;
 
+    @Setter
+    @Value("${offender-search.max-retries:3}")
+    private int maxRetries;
+
+    @Setter
+    @Value("${offender-search.min-backoff-seconds:5}")
+    private int minBackOffSeconds;
+
     private final WebClient webClient;
 
-    private final EventBus eventBus;
-
-    private final ObjectMapper objectMapper;
-
     @Autowired
-    public OffenderSearchRestClient(@Qualifier("offenderSearchWebClient") WebClient webClient, EventBus eventBus, com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
+    public OffenderSearchRestClient(@Qualifier("offenderSearchWebClient") WebClient webClient) {
         super();
         this.webClient = webClient;
-        this.eventBus = eventBus;
-        this.objectMapper = objectMapper;
     }
 
     public Mono<SearchResponse> search(Name name, LocalDate dateOfBirth){
@@ -58,7 +66,12 @@ public class OffenderSearchRestClient {
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .bodyToMono(SearchResponse.class)
-                .onErrorResume(throwable -> handleError(throwable, body));
+                .retryWhen(Retry.backoff(maxRetries, Duration.ofSeconds(minBackOffSeconds))
+                                .jitter(0.0d)
+                                .doAfterRetryAsync(this::logRetrySignal)
+                                .filter(EXCEPTION_RETRY_FILTER))
+                .onErrorResume(this::handleError)
+            ;
     }
 
     private WebClient.RequestBodySpec post() {
@@ -86,22 +99,13 @@ public class OffenderSearchRestClient {
         return true;
     }
 
-    private Mono<? extends SearchResponse> handleError(Throwable throwable, MatchRequest body) {
-        String incomingMessage = null;
-        try {
-            // Would rather this didn't block but also want to provide a helpful error message
-            // TODO: come up with a better solution
-            // We could send a toString representation of the messageBody or do the parsing to JSON in the EventBus
-            //noinspection BlockingMethodInNonBlockingContext
-            incomingMessage = objectMapper.writeValueAsString(body);
-        } catch (JsonProcessingException e) {
-            log.error(e.getMessage());
+    private Mono<? extends SearchResponse> handleError(Throwable throwable) {
+
+        if (Exceptions.isRetryExhausted(throwable)) {
+            log.error("Retry error :{} with maximum of {}", throwable.getMessage(), maxRetries);
+            return Mono.error(throwable);
         }
-        eventBus.post(OffenderSearchFailureEvent.builder()
-                .failureMessage(throwable.getMessage())
-                .requestJson(incomingMessage)
-                .build());
-        return Mono.empty();
+        return Mono.error(throwable);
     }
 
     private MatchRequest buildRequestBody(Name fullName, LocalDate dateOfBirth) {
@@ -116,4 +120,35 @@ public class OffenderSearchRestClient {
         return builder.build();
     }
 
+    private Mono<Void> logRetrySignal(RetrySignal retrySignal) {
+        log.error("Error from call to offender search, at attempt {} of {}. Root Cause {} ",
+            retrySignal.totalRetries(), maxRetries, retrySignal.failure());
+        return Mono.empty();
+    }
+
+    /**
+     * Filter which decides whether or not to retry. Return true if we do wish to retry.
+     */
+    static final Predicate<? super Throwable> EXCEPTION_RETRY_FILTER = new Predicate<Throwable>() {
+        @Override
+        public boolean test(Throwable throwable) {
+            boolean retry = true;
+            if (throwable instanceof WebClientResponseException) {
+                WebClientResponseException ex = (WebClientResponseException) throwable;
+                HttpStatus status = ex.getStatusCode();
+                switch (status) {
+                    case NOT_FOUND:
+                    case FORBIDDEN:
+                    case UNAUTHORIZED:
+                    case TOO_MANY_REQUESTS:
+                        retry = false;
+                        break;
+                    default:
+                        retry = true;
+                }
+            }
+
+            return retry;
+        }
+    };
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClient.java
@@ -58,7 +58,7 @@ public class OffenderSearchRestClient {
 
     public Mono<SearchResponse> search(Name name, LocalDate dateOfBirth){
         if (!validate(name, dateOfBirth)) {
-            return Mono.empty();
+            return Mono.error(new IllegalArgumentException("Invalid parameters passed for offender search"));
         }
         MatchRequest body = buildRequestBody(name, dateOfBirth);
         return post()

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.probation.courtcasematcher.service;
 
-import com.google.common.eventbus.EventBus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/MatcherService.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcasematcher.service;
 
+import com.google.common.eventbus.EventBus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryEventType.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryEventType.java
@@ -4,6 +4,7 @@ public enum TelemetryEventType {
     OFFENDER_EXACT_MATCH("PiCOffenderExactMatch"),
     OFFENDER_PARTIAL_MATCH("PiCOffenderPartialMatch"),
     OFFENDER_NO_MATCH("PiCOffenderNoMatch"),
+    OFFENDER_MATCH_ERROR("PiCOffenderMatchError"),
     COURT_LIST_MESSAGE_RECEIVED("PiCCourtListMessageReceived"),
     COURT_LIST_RECEIVED("PiCCourtListReceived"),
     COURT_CASE_RECEIVED("PiCCourtCaseReceived")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,8 @@ court-case-service:
 offender-search:
   post-match-url: /match
   ping-path: /health/ping
+  max-retries: 3
+  min-backoff-seconds: 5
 
 nomis-oauth:
   ping-path: /auth/ping

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -33,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.web.reactive.function.client.WebClientResponseException.TooManyRequests;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Name;
@@ -173,12 +175,13 @@ class EventListenerTest {
         verify(matcherService).getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE);
         verify(courtCaseService).createCase(courtCase, searchResponse);
         verify(telemetryService).trackOffenderMatchEvent(courtCase, searchResponse);
+        verifyNoMoreInteractions(matcherService, courtCaseService, telemetryService);
     }
 
     @DisplayName("Check the match event when the call to the matcher service returns an empty response")
     @Test
     void givenSearchWhichFails_whenCourtCaseMatched_thenSave() {
-        when(matcherService.getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE)).thenReturn(Mono.empty());
+        when(matcherService.getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE)).thenReturn(Mono.error(new IllegalArgumentException()));
 
         eventListener.courtCaseMatchEvent(CourtCaseMatchEvent.builder().courtCase(courtCase).build());
 
@@ -188,33 +191,33 @@ class EventListenerTest {
             .build();
         verify(matcherService).getSearchResponse(DEFENDANT_NAME, DEFENDANT_DOB, COURT_CODE, CASE);
         verify(courtCaseService).createCase(courtCase, searchResponse);
-        verify(telemetryService).trackOffenderMatchEvent(courtCase, searchResponse);
+        verify(telemetryService).trackOffenderMatchFailureEvent(courtCase);
+        verifyNoMoreInteractions(matcherService, courtCaseService, telemetryService);
     }
 
-    @DisplayName("Check the match event when the call to the matcher service returns an empty response")
-    @Test
-    void whenOffenderSearchFails_thenLogError() {
-
-        String messageBody = "{\n"
-            + "    \"firstName\": \"David\",\n"
-            + "    \"surname\": \"JONES\",\n"
-            + "    \"dateOfBirth\": \"1990-01-01\"\n"
-            + "}";
-
-        eventListener.offenderSearchFailureEvent(OffenderSearchFailureEvent.builder()
-                                                                            .requestJson(messageBody)
-                                                                            .failureMessage("ERROR")
-                                                                            .build());
-
-        verify(mockAppender, atLeast(1)).doAppend(captorLoggingEvent.capture());
-        List<LoggingEvent> events = captorLoggingEvent.getAllValues();
-        LoggingEvent loggingEvent = events.get(0);
-
-        Assertions.assertAll(() -> assertThat(events.size()).isGreaterThanOrEqualTo(1),
-            () -> assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR),
-            () -> assertThat(loggingEvent.getFormattedMessage().trim())
-                                .contains(messageBody)
-        );
-    }
+//    @DisplayName("Check the match event when the call to the matcher service returns an empty response")
+//    @Test
+//    void whenOffenderSearchFails_thenLogError() {
+//
+//        String messageBody = "{\n"
+//            + "    \"firstName\": \"David\",\n"
+//            + "    \"surname\": \"JONES\",\n"
+//            + "    \"dateOfBirth\": \"1990-01-01\"\n"
+//            + "}";
+//
+//        eventListener.offenderSearchFailureEvent(OffenderSearchFailureEvent.builder()
+//                                                                            .failureMessage("ERROR")
+//                                                                            .build());
+//
+//        verify(mockAppender, atLeast(1)).doAppend(captorLoggingEvent.capture());
+//        List<LoggingEvent> events = captorLoggingEvent.getAllValues();
+//        LoggingEvent loggingEvent = events.get(0);
+//
+//        Assertions.assertAll(() -> assertThat(events.size()).isGreaterThanOrEqualTo(1),
+//            () -> assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR),
+//            () -> assertThat(loggingEvent.getFormattedMessage().trim())
+//                                .contains(messageBody)
+//        );
+//    }
 
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/event/EventListenerTest.java
@@ -195,29 +195,4 @@ class EventListenerTest {
         verifyNoMoreInteractions(matcherService, courtCaseService, telemetryService);
     }
 
-//    @DisplayName("Check the match event when the call to the matcher service returns an empty response")
-//    @Test
-//    void whenOffenderSearchFails_thenLogError() {
-//
-//        String messageBody = "{\n"
-//            + "    \"firstName\": \"David\",\n"
-//            + "    \"surname\": \"JONES\",\n"
-//            + "    \"dateOfBirth\": \"1990-01-01\"\n"
-//            + "}";
-//
-//        eventListener.offenderSearchFailureEvent(OffenderSearchFailureEvent.builder()
-//                                                                            .failureMessage("ERROR")
-//                                                                            .build());
-//
-//        verify(mockAppender, atLeast(1)).doAppend(captorLoggingEvent.capture());
-//        List<LoggingEvent> events = captorLoggingEvent.getAllValues();
-//        LoggingEvent loggingEvent = events.get(0);
-//
-//        Assertions.assertAll(() -> assertThat(events.size()).isGreaterThanOrEqualTo(1),
-//            () -> assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR),
-//            () -> assertThat(loggingEvent.getFormattedMessage().trim())
-//                                .contains(messageBody)
-//        );
-//    }
-
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientTest.java
@@ -47,24 +47,24 @@ class OffenderSearchRestClientTest {
         assertThat(EXCEPTION_RETRY_FILTER.test(exception)).isTrue();
     }
 
-    @DisplayName("The mono will be empty with invalid name")
+    @DisplayName("The mono will be an error with invalid name")
     @Test
-    void givenInvalidName_whenSearch_thenReturnEmptyMono() {
+    void givenInvalidName_whenSearch_thenReturnError() {
         Name name = Name.builder().forename1("not").surname("").build();
         Mono<SearchResponse> searchResponseMono = restClient.search(name, LocalDate.of(1999, 4, 5));
 
         StepVerifier.create(searchResponseMono)
-            .verifyComplete();
+            .verifyError(IllegalArgumentException.class);
     }
 
-    @DisplayName("The mono will be empty with null date of birth")
+    @DisplayName("The mono will be an error with null date of birth")
     @Test
-    void givenNullDateOfBirth_whenSearch_thenReturnEmptyMono() {
+    void givenNullDateOfBirth_whenSearch_thenReturnError() {
         Name name = Name.builder().forename1("Arthur").surname("MORGAN").build();
         Mono<SearchResponse> searchResponseMono = restClient.search(name, null);
 
         StepVerifier.create(searchResponseMono)
-            .verifyComplete();
+            .verifyError(IllegalArgumentException.class);
     }
 
     private static WebClientResponseException createException(HttpStatus httpStatus) {

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientTest.java
@@ -1,0 +1,73 @@
+package uk.gov.justice.probation.courtcasematcher.restclient;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Name;
+import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.probation.courtcasematcher.restclient.OffenderSearchRestClient.EXCEPTION_RETRY_FILTER;
+
+@ExtendWith(MockitoExtension.class)
+class OffenderSearchRestClientTest {
+
+    private static final HttpHeaders HEADERS = new HttpHeaders(new LinkedMultiValueMap<>());
+
+    @InjectMocks
+    private OffenderSearchRestClient restClient;
+
+    @DisplayName("Will not retry for these HTTP status codes")
+    @ParameterizedTest(name = "{index} => status=''{0}''")
+    @EnumSource(value = HttpStatus.class, names = {"UNAUTHORIZED", "NOT_FOUND", "FORBIDDEN", "TOO_MANY_REQUESTS"})
+    void givenUnauthorizedError_whenUsePredicate_thenNoRetry(HttpStatus httpStatus) {
+
+        WebClientResponseException exception = createException(httpStatus);
+
+        assertThat(EXCEPTION_RETRY_FILTER.test(exception)).isFalse();
+    }
+
+    @DisplayName("Will retry for these HTTP status codes (and lots of others)")
+    @ParameterizedTest(name = "{index} => status=''{0}''")
+    @EnumSource(value = HttpStatus.class, names = {"INTERNAL_SERVER_ERROR", "REQUEST_TIMEOUT"})
+    void givenHttpStatusToRetry_whenUsePredicate_thenRetry(HttpStatus httpStatus) {
+        WebClientResponseException exception = createException(httpStatus);
+
+        assertThat(EXCEPTION_RETRY_FILTER.test(exception)).isTrue();
+    }
+
+    @DisplayName("The mono will be empty with invalid name")
+    @Test
+    void givenInvalidName_whenSearch_thenReturnEmptyMono() {
+        Name name = Name.builder().forename1("not").surname("").build();
+        Mono<SearchResponse> searchResponseMono = restClient.search(name, LocalDate.of(1999, 4, 5));
+
+        StepVerifier.create(searchResponseMono)
+            .verifyComplete();
+    }
+
+    @DisplayName("The mono will be empty with null date of birth")
+    @Test
+    void givenNullDateOfBirth_whenSearch_thenReturnEmptyMono() {
+        Name name = Name.builder().forename1("Arthur").surname("MORGAN").build();
+        Mono<SearchResponse> searchResponseMono = restClient.search(name, null);
+
+        StepVerifier.create(searchResponseMono)
+            .verifyComplete();
+    }
+
+    private static WebClientResponseException createException(HttpStatus httpStatus) {
+        return WebClientResponseException.create(httpStatus.value(), "", HEADERS, "".getBytes(), null);
+    }
+}

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.google.common.eventbus.EventBus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Name;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Match;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
@@ -44,10 +46,21 @@ class MatcherServiceTest {
     private static final String DEFAULT_PROBATION_STATUS = "No record";
     private static final String MATCHES_PROBATION_STATUS = "Possible nDelius record";
 
-    private final LocalDate DEF_DOB = LocalDate.of(2000, 6, 17);
-    private final Name DEF_NAME = Name.builder().forename1("Arthur")
+
+
+    private static final LocalDate DEF_DOB = LocalDate.of(2000, 6, 17);
+    private static final Name DEF_NAME = Name.builder().forename1("Arthur")
                                                 .surname("MORGAN")
                                                 .build();
+
+    private static final CourtCase COURT_CASE = CourtCase.builder()
+        .caseNo(CASE_NO)
+        .courtCode(COURT_CODE)
+        .name(DEF_NAME)
+        .defendantDob(DEF_DOB)
+        .defendantName(DEF_NAME.getFullName())
+        .build();
+
 
     private final OtherIds otherIds = OtherIds.builder()
         .crn(CRN)
@@ -83,6 +96,9 @@ class MatcherServiceTest {
 
     @Mock
     private OffenderSearchRestClient offenderSearchRestClient;
+
+    @Mock
+    private EventBus eventBus;
 
     @Mock
     private Appender<ILoggingEvent> mockAppender;

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryServiceTest.java
@@ -51,6 +51,7 @@ class TelemetryServiceTest {
     private static final String COURT_CODE = "B10JQ00";
     private static final String CASE_NO = "1234567890";
     private static final String CRN = "D12345";
+    private static final String PNC = "PNC/123";
     private static final String COURT_ROOM = "01";
     private static final LocalDate DATE_OF_HEARING = LocalDate.of(2020, Month.NOVEMBER, 5);
     private static Info info;
@@ -90,11 +91,13 @@ class TelemetryServiceTest {
                 .session(session)
                 .build())
             .caseNo(CASE_NO)
+            .pnc(PNC)
             .build();
 
         courtCase = CourtCase.builder()
                 .courtCode(COURT_CODE)
                 .caseNo(CASE_NO)
+                .pnc(PNC)
                 .sessionStartTime(DATE_OF_HEARING.atStartOfDay())
                 .build();
     }
@@ -130,7 +133,7 @@ class TelemetryServiceTest {
             entry(MATCHES_KEY, "1"),
             entry(MATCHED_BY_KEY, OffenderSearchMatchType.ALL_SUPPLIED.name()),
             entry(CRNS_KEY, CRN),
-            entry(PNC_KEY, null)
+            entry(PNC_KEY, PNC)
         );
     }
 
@@ -157,7 +160,7 @@ class TelemetryServiceTest {
             entry(MATCHES_KEY, "2"),
             entry(MATCHED_BY_KEY, OffenderSearchMatchType.PARTIAL_NAME.name()),
             entry(CRNS_KEY, CRN + "," + "X123454"),
-            entry(PNC_KEY, null)
+            entry(PNC_KEY, PNC)
         );
     }
 
@@ -183,7 +186,7 @@ class TelemetryServiceTest {
             entry(MATCHES_KEY, "1"),
             entry(MATCHED_BY_KEY, OffenderSearchMatchType.PARTIAL_NAME.name()),
             entry(CRNS_KEY, CRN),
-            entry(PNC_KEY, null)
+            entry(PNC_KEY, PNC)
         );
     }
 
@@ -205,7 +208,25 @@ class TelemetryServiceTest {
             entry(COURT_CODE_KEY, COURT_CODE),
             entry(CASE_NO_KEY, CASE_NO),
             entry(HEARING_DATE_KEY, "2020-11-05"),
-            entry(PNC_KEY, null)
+            entry(PNC_KEY, PNC)
+        );
+    }
+
+    @DisplayName("Record the event when the call to matcher service fails")
+    @Test
+    void whenMatchEventFails_thenRecord() {
+
+        telemetryService.trackOffenderMatchFailureEvent(courtCase);
+
+        verify(telemetryClient).trackEvent(eq("PiCOffenderMatchError"), propertiesCaptor.capture(), eq(Collections.emptyMap()));
+
+        Map<String, String> properties = propertiesCaptor.getValue();
+        assertThat(properties).hasSize(4);
+        assertThat(properties).contains(
+            entry(COURT_CODE_KEY, COURT_CODE),
+            entry(CASE_NO_KEY, CASE_NO),
+            entry(HEARING_DATE_KEY, "2020-11-05"),
+            entry(PNC_KEY, PNC)
         );
     }
 
@@ -228,6 +249,7 @@ class TelemetryServiceTest {
         );
     }
 
+    @DisplayName("Record the event when a court list is received")
     @Test
     void whenCourtListReceived_thenRecord() {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -22,6 +22,8 @@ offender-search:
   base-url: http://localhost:8090
   disable-authentication: true
   ping-path: /ping
+  min-backoff-seconds: 1
+  max-retries: 2
 
 nomis-oauth:
   base-url: http://localhost:8090


### PR DESCRIPTION
IN addition to the extra lines of code for retry, OffenderSearchRestClient  no longer has the event bus. It returns a Mono error or a searchResponse and not an empty Mono. 
The integration tests on the rest client which handle 404, 401 and so on now no longer check for an empty mono but an error with StepVerifier
Tests on the rest client which aren't relying on WireMock and therefore aren't really integration have been split out to a non-integration test.