### PR TITLE
✨ Get rid of junit 4 and refactor wiremock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,10 +92,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-client'
 
     testImplementation(platform("org.junit:junit-bom:5.7.1"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("junit:junit:4.13.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
         because 'allows tests to run from IDEs that bundle older version of launcher'
     }
@@ -113,6 +110,8 @@ dependencies {
     testCompile 'org.mockito:mockito-core:3.8.0'
     testCompile 'org.apache.activemq:artemis-junit:2.17.0'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation("com.github.tomakehurst:wiremock:2.27.2")
 
     agentDeps 'com.microsoft.azure:applicationinsights-agent:3.0.2'
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/application/healthchecks/PingerTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/application/healthchecks/PingerTest.java
@@ -1,27 +1,27 @@
 package uk.gov.justice.probation.courtcasematcher.application.healthchecks;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockExtension;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockMockServer;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.actuate.health.Status.DOWN;
 import static org.springframework.boot.actuate.health.Status.UP;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class PingerTest {
 
     private static final String BASE_URL = "http://localhost:8090";
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
-            .port(8090)
-            .usingFilesUnderClasspath("mocks"));
+    private static final WiremockMockServer MOCK_SERVER = new WiremockMockServer(8090);
+
+    @RegisterExtension
+    static WiremockExtension wiremockExtension = new WiremockExtension(MOCK_SERVER);
 
     @Test
     public void when200_thenUp() {

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/health/HealthCheckTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/health/HealthCheckTest.java
@@ -1,12 +1,10 @@
 package uk.gov.justice.probation.courtcasematcher.health;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.RestAssured;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
@@ -15,19 +13,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.probation.courtcasematcher.TestConfig;
 import uk.gov.justice.probation.courtcasematcher.application.TestMessagingConfig;
 import uk.gov.justice.probation.courtcasematcher.application.healthchecks.SqsCheck;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockExtension;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockMockServer;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 @Import(TestMessagingConfig.class)
 public class HealthCheckTest {
@@ -42,14 +39,14 @@ public class HealthCheckTest {
     private SqsCheck sqsCheck;
 
     @LocalServerPort
-    int port;
+    private int port;
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
-        .port(8090)
-        .usingFilesUnderClasspath("mocks"));
+    private static final WiremockMockServer MOCK_SERVER = new WiremockMockServer(8090);
 
-    @Before
+    @RegisterExtension
+    static WiremockExtension wiremockExtension = new WiremockExtension(MOCK_SERVER);
+
+    @BeforeEach
     public void before() {
         TestConfig.configureRestAssuredForIntTest(port);
         RestAssured.basePath = "/actuator";

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClientIntTest.java
@@ -12,13 +12,11 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.eventbus.EventBus;
 import lombok.Builder;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
@@ -30,7 +28,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import reactor.core.Exceptions;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseFailureEvent;
 import uk.gov.justice.probation.courtcasematcher.event.CourtCaseSuccessEvent;
@@ -44,8 +41,9 @@ import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Offender
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.ProbationStatusDetail;
 import uk.gov.justice.probation.courtcasematcher.model.externaldocumentrequest.Name;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockExtension;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockMockServer;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -55,7 +53,6 @@ import static org.mockito.Mockito.verify;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.gov.justice.probation.courtcasematcher.restclient.OffenderSearchRestClientTest.createException;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @ActiveProfiles("test")
 public class CourtCaseRestClientIntTest {
@@ -95,13 +92,13 @@ public class CourtCaseRestClientIntTest {
     @Autowired
     private CourtCaseRestClient restClient;
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
-            .port(8090)
-            .usingFilesUnderClasspath("mocks"));
+    private static final WiremockMockServer MOCK_SERVER = new WiremockMockServer(8090);
 
-    @Before
-    public void before() {
+    @RegisterExtension
+    static WiremockExtension wiremockExtension = new WiremockExtension(MOCK_SERVER);
+
+    @BeforeEach
+    public void beforeEach() {
         MockitoAnnotations.openMocks(this);
         Logger logger = (Logger) getLogger(LoggerFactory.getLogger(CourtCaseRestClient.class).getName());
         logger.addAppender(mockAppender);

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientIntTest.java
@@ -1,15 +1,15 @@
 package uk.gov.justice.probation.courtcasematcher.restclient;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.junit.Rule;
-import org.junit.Test;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -19,15 +19,11 @@ import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchReque
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.Offender;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.OffenderSearchMatchType;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.SearchResponse;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockExtension;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockMockServer;
 
-import java.time.LocalDate;
-import java.time.Month;
-import java.util.Optional;
-
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(TestMessagingConfig.class)
@@ -36,13 +32,12 @@ public class OffenderSearchRestClientIntTest {
     @Autowired
     private OffenderSearchRestClient restClient;
 
-    private MatchRequest.Factory matchRequestFactory = new MatchRequest.Factory();
+    private final MatchRequest.Factory matchRequestFactory = new MatchRequest.Factory();
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
-            .port(8090)
-            .stubRequestLoggingDisabled(false)
-            .usingFilesUnderClasspath("mocks"));
+    private static final WiremockMockServer MOCK_SERVER = new WiremockMockServer(8090);
+
+    @RegisterExtension
+    static WiremockExtension wiremockExtension = new WiremockExtension(MOCK_SERVER);
 
     @Test
     public void givenSingleMatchReturned_whenSearch_thenReturnIt() {

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/wiremock/WiremockExtension.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/wiremock/WiremockExtension.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.probation.courtcasematcher.wiremock;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class WiremockExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+
+    private final WiremockMockServer wiremockServer;
+
+    public WiremockExtension(WiremockMockServer server) {
+        this.wiremockServer = server;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        wiremockServer.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        wiremockServer.stop();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) {
+        wiremockServer.resetRequests();
+    }
+
+}

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/wiremock/WiremockMockServer.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/wiremock/WiremockMockServer.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.probation.courtcasematcher.wiremock;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+public class WiremockMockServer extends WireMockServer {
+
+    private static final String DEFAULT_PATH = "mocks";
+
+    public WiremockMockServer(final int port) {
+        this(port, DEFAULT_PATH);
+    }
+
+    public WiremockMockServer(final int port, final String fileDirectory) {
+        super(WireMockConfiguration.wireMockConfig().port(port)
+            .usingFilesUnderClasspath(fileDirectory)
+            .jettyStopTimeout(10000L));
+    }
+
+}


### PR DESCRIPTION
First part of 1096. Wanted to split it. This is just refactoring to get rid of Junit 4 which was only there to support Wiremock. There's only unit test changes here plus build.gradle.
The WiremockExtension and server were taken from community API where the same things happen.