### PR TITLE
✨ 1087 - return the probation status as-is 

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
@@ -1,10 +1,7 @@
 package uk.gov.justice.probation.courtcasematcher.model.mapper;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.Address;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCase;
@@ -28,17 +25,10 @@ import java.util.stream.Collectors;
 
 import static java.util.Comparator.comparing;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @AllArgsConstructor
 @Component
 @Slf4j
 public class CaseMapper {
-
-    @Value("${probation-status-reference.default}")
-    private final String defaultProbationStatus;
-
-    @Value("${probation-status-reference.nonExactMatch}")
-    private final String nonExactProbationStatus;
 
     public CourtCase newFromCase(Case aCase) {
         return getCourtCaseBuilderFromCase(aCase)
@@ -46,7 +36,7 @@ public class CaseMapper {
             .build();
     }
 
-    private CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(CourtCase courtCase, String probationStatus) {
+    private CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(CourtCase courtCase) {
         return CourtCase.builder()
             .caseNo(courtCase.getCaseNo())
             .courtCode(courtCase.getCourtCode())
@@ -62,7 +52,6 @@ public class CaseMapper {
             .pnc(courtCase.getPnc())
             .listNo(courtCase.getListNo())
             .sessionStartTime(courtCase.getSessionStartTime())
-            .probationStatus(Optional.ofNullable(probationStatus).orElse(defaultProbationStatus))
             .nationality1(courtCase.getNationality1())
             .nationality2(courtCase.getNationality2())
             .preSentenceActivity(courtCase.isPreSentenceActivity())
@@ -85,7 +74,6 @@ public class CaseMapper {
             .pnc(aCase.getPnc())
             .listNo(aCase.getListNo())
             .sessionStartTime(aCase.getBlock().getSession().getSessionStartTime())
-            .probationStatus(defaultProbationStatus)
             .nationality1(aCase.getNationality1())
             .nationality2(aCase.getNationality2())
             .offences(Optional.ofNullable(aCase.getOffences()).map(CaseMapper::fromOffences).orElse(Collections.emptyList()));
@@ -153,8 +141,7 @@ public class CaseMapper {
 
     public CourtCase newFromCourtCaseWithMatches(CourtCase incomingCase, MatchDetails matchDetails) {
 
-        String nonExactProbationStatus = matchDetails.getMatches().size() >= 1 ? this.nonExactProbationStatus : defaultProbationStatus;
-        CourtCaseBuilder courtCaseBuilder = getCourtCaseBuilderFromCase(incomingCase, nonExactProbationStatus)
+        CourtCaseBuilder courtCaseBuilder = getCourtCaseBuilderFromCase(incomingCase)
             .groupedOffenderMatches(buildGroupedOffenderMatch(matchDetails.getMatches(), matchDetails.getMatchType()));
 
         if (matchDetails.isExactMatch()) {
@@ -164,7 +151,7 @@ public class CaseMapper {
                 .breach(Optional.ofNullable(probationStatus).map(ProbationStatus::getInBreach).orElse(null))
                 .previouslyKnownTerminationDate(
                     Optional.ofNullable(probationStatus).map(ProbationStatus::getPreviouslyKnownTerminationDate).orElse(null))
-                .probationStatus(Optional.ofNullable(probationStatus).map(ProbationStatus::getStatus).orElse(defaultProbationStatus))
+                .probationStatus(Optional.ofNullable(probationStatus).map(ProbationStatus::getStatus).orElse(null))
                 .preSentenceActivity(Optional.ofNullable(probationStatus).map(ProbationStatus::isPreSentenceActivity).orElse(false))
                 .crn(offender.getOtherIds().getCrn())
                 .cro(offender.getOtherIds().getCroNumber())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,10 +74,6 @@ web:
     read-timeout-ms: 5000
     write-timeout-ms: 5000
 
-probation-status-reference:
-  default: "No record"
-  nonExactMatch: "Possible nDelius record"
-
 # Libra feed has today's case list and another case list for this many days hence. e.g. 25th and 28th July
 case-feed-future-date-offset: 3
 ou-code-length: 5

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapperTest.java
@@ -39,8 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CaseMapperTest {
 
-    private static final String DEFAULT_PROBATION_STATUS = "No record";
-    private static final String MATCHES_PROBATION_STATUS = "Possible nDelius record";
     private static final LocalDate DATE_OF_BIRTH = LocalDate.of(1969, Month.AUGUST, 26);
     private static final LocalDate DATE_OF_HEARING = LocalDate.of(2020, Month.FEBRUARY, 29);
     private static final LocalTime START_TIME = LocalTime.of(9, 10);
@@ -99,7 +97,7 @@ class CaseMapperTest {
             .offences(singletonList(buildOffence("NEW Theft from a person", 1)))
             .build();
 
-        caseMapper = new CaseMapper(DEFAULT_PROBATION_STATUS, MATCHES_PROBATION_STATUS);
+        caseMapper = new CaseMapper();
     }
 
     @DisplayName("Map a new case from gateway case but with no offences")
@@ -113,7 +111,7 @@ class CaseMapperTest {
         assertThat(courtCase.getCaseId()).isEqualTo("321321");
         assertThat(courtCase.getCourtCode()).isEqualTo(COURT_CODE);
         assertThat(courtCase.getCourtRoom()).isEqualTo("00");
-        assertThat(courtCase.getProbationStatus()).isEqualTo(DEFAULT_PROBATION_STATUS);
+        assertThat(courtCase.getProbationStatus()).isNull();
         assertThat(courtCase.getDefendantAddress().getLine1()).isEqualTo("line 1");
         assertThat(courtCase.getDefendantAddress().getLine2()).isEqualTo("line 2");
         assertThat(courtCase.getDefendantAddress().getLine3()).isEqualTo("line 3");
@@ -191,7 +189,7 @@ class CaseMapperTest {
 
         assertThat(courtCaseNew).isNotSameAs(courtCase);
         assertThat(courtCaseNew.getCrn()).isNull();
-        assertThat(courtCaseNew.getProbationStatus()).isEqualTo(MATCHES_PROBATION_STATUS);
+        assertThat(courtCaseNew.getProbationStatus()).isNull();
         assertThat(courtCaseNew.getBreach()).isNull();
         assertThat(courtCaseNew.getPreviouslyKnownTerminationDate()).isNull();
         assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(1);
@@ -217,7 +215,7 @@ class CaseMapperTest {
 
         assertThat(courtCaseNew).isNotSameAs(courtCase);
         assertThat(courtCaseNew.getCrn()).isEqualTo(CRN);
-        assertThat(courtCaseNew.getProbationStatus()).isEqualTo(DEFAULT_PROBATION_STATUS);
+        assertThat(courtCaseNew.getProbationStatus()).isNull();
         assertThat(courtCaseNew.getBreach()).isNull();
         assertThat(courtCaseNew.getPreviouslyKnownTerminationDate()).isNull();
         assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(1);
@@ -247,7 +245,7 @@ class CaseMapperTest {
 
         assertThat(courtCaseNew).isNotSameAs(courtCase);
         assertThat(courtCaseNew.getCrn()).isNull();
-        assertThat(courtCaseNew.getProbationStatus()).isEqualTo(MATCHES_PROBATION_STATUS);
+        assertThat(courtCaseNew.getProbationStatus()).isNull();
         assertThat(courtCaseNew.getBreach()).isNull();
         assertThat(courtCaseNew.getPreviouslyKnownTerminationDate()).isNull();
         assertThat(courtCaseNew.getGroupedOffenderMatches().getMatches()).hasSize(2);


### PR DESCRIPTION
Allow null, do not map to some default or "Possible nDelius record". 

We will move the mapping to default in to court-case-service. court-case-matcher just passes on what it is told. So if there are multiple matches, there is no probation status so that will be null. 
