### PR TITLE
Pic 960 consumer ccs pact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,16 @@ jobs:
       - store_artifacts:
           path: build/reports/tests
 
+  pact-publish:
+    executor: builder
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle" }}
+            - gradle-
+      - run: ./gradlew -Dpact.writer.overwrite=true test pactPublish
+
   build_docker:
     executor: deployer
     steps:
@@ -244,6 +254,12 @@ workflows:
           name: helm_lint_dev
           env: dev
           chart_name: court-case-matcher
+      - pact-publish:
+          requires:
+            - build_docker
+#          filters:
+#            branches:
+#              only: main
       - deploy_dev:
           requires:
             - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,16 +250,16 @@ workflows:
       - build_docker:
           requires:
             - build
+      - pact-publish:
+          requires:
+            - build
+          filters:
+            branches:
+              only: main
       - dps/helm_lint:
           name: helm_lint_dev
           env: dev
           chart_name: court-case-matcher
-      - pact-publish:
-          requires:
-            - build_docker
-#          filters:
-#            branches:
-#              only: main
       - deploy_dev:
           requires:
             - build_docker

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'org.springframework.boot' version '2.4.4'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'com.github.ben-manes.versions' version '0.38.0'
+    id "au.com.dius.pact" version "4.2.3"
 }
 
 repositories {
@@ -115,6 +116,9 @@ dependencies {
 
     testImplementation("com.github.tomakehurst:wiremock:2.27.2")
 
+    testImplementation 'au.com.dius.pact.consumer:junit5:4.2.3'
+    testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
+
     agentDeps 'com.microsoft.azure:applicationinsights-agent:3.0.3'
 }
 
@@ -169,6 +173,15 @@ task copyAgent(type: Copy) {
 task copyAgentConfig(type: Copy) {
     from "applicationinsights.json"
     into "$buildDir/libs"
+}
+
+pact {
+    publish {
+        pactBrokerUrl = System.getenv("PACTBROKER_URL")
+        pactBrokerUsername = System.getenv("PACTBROKER_AUTH_USERNAME")
+        pactBrokerPassword = System.getenv("PACTBROKER_AUTH_PASSWORD")
+        pactDirectory = 'build/pacts'
+    }
 }
 
 assemble.dependsOn copyAgent

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/model/mapper/CaseMapper.java
@@ -31,12 +31,12 @@ import static java.util.Comparator.comparing;
 public class CaseMapper {
 
     public static CourtCase newFromCase(Case aCase) {
-        return getCourtCaseBuilderFromCase(aCase)
+        return newFromLibraCase(aCase)
             .isNew(true)
             .build();
     }
 
-    private static CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(CourtCase courtCase) {
+    private static CourtCase.CourtCaseBuilder newFromCourtCase(CourtCase courtCase) {
         return CourtCase.builder()
             .caseNo(courtCase.getCaseNo())
             .courtCode(courtCase.getCourtCode())
@@ -58,7 +58,7 @@ public class CaseMapper {
             .offences(courtCase.getOffences());
     }
 
-    private static CourtCase.CourtCaseBuilder getCourtCaseBuilderFromCase(Case aCase) {
+    private static CourtCase.CourtCaseBuilder newFromLibraCase(Case aCase) {
         return CourtCase.builder()
             .caseNo(aCase.getCaseNo())
             .courtCode(aCase.getBlock().getSession().getCourtCode())
@@ -177,7 +177,7 @@ public class CaseMapper {
 
     public static CourtCase newFromCourtCaseWithMatches(CourtCase incomingCase, MatchDetails matchDetails) {
 
-        CourtCaseBuilder courtCaseBuilder = getCourtCaseBuilderFromCase(incomingCase)
+        CourtCaseBuilder courtCaseBuilder = newFromCourtCase(incomingCase)
             .groupedOffenderMatches(buildGroupedOffenderMatch(matchDetails.getMatches(), matchDetails.getMatchType()));
 
         if (matchDetails.isExactMatch()) {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
@@ -172,16 +172,6 @@ public class CourtCaseRestClient {
         return addSpecAuthAttribute(spec, path);
     }
 
-//    private WebClient.RequestHeadersSpec<?> put(String path, Map<LocalDate, List<String>> casesByDate) {
-//        var spec = webClient
-//            .put()
-//            .uri(uriBuilder -> uriBuilder.path(path).build())
-//            .body(Mono.just(casesByDate), Map.class)
-//            .accept(MediaType.APPLICATION_JSON);
-//
-//        return addSpecAuthAttribute(spec, path);
-//    }
-
     private WebClient.RequestHeadersSpec<?> post(String path, GroupedOffenderMatches request) {
         WebClient.RequestHeadersSpec<?> spec = webClient
             .post()
@@ -225,18 +215,6 @@ public class CourtCaseRestClient {
             clientResponse.toString().getBytes(),
             StandardCharsets.UTF_8);
     }
-//
-//    private Mono<? extends Throwable> handleError(ClientResponse clientResponse, Supplier<Throwable> notFoundError) {
-//        final HttpStatus httpStatus = clientResponse.statusCode();
-//        if (HttpStatus.NOT_FOUND.equals(httpStatus)) {
-//            return Mono.error(notFoundError.get());
-//        }
-//        throw WebClientResponseException.create(httpStatus.value(),
-//            httpStatus.name(),
-//            clientResponse.headers().asHttpHeaders(),
-//            clientResponse.toString().getBytes(),
-//            StandardCharsets.UTF_8);
-//    }
 
     private Mono<Void> logRetrySignal(RetrySignal retrySignal, String messageFormat, String initialError) {
         if (retrySignal.totalRetries() > 0 ) {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/CourtCaseRestClient.java
@@ -32,7 +32,6 @@ import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.CourtCas
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.GroupedOffenderMatches;
 import uk.gov.justice.probation.courtcasematcher.model.courtcaseservice.ProbationStatusDetail;
 import uk.gov.justice.probation.courtcasematcher.restclient.exception.CourtCaseNotFoundException;
-import uk.gov.justice.probation.courtcasematcher.restclient.exception.CourtNotFoundException;
 
 import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;
 import static uk.gov.justice.probation.courtcasematcher.restclient.OffenderSearchRestClient.EXCEPTION_RETRY_FILTER;
@@ -41,7 +40,6 @@ import static uk.gov.justice.probation.courtcasematcher.restclient.OffenderSearc
 @Slf4j
 public class CourtCaseRestClient {
 
-    private static final String ERR_MSG_FORMAT_PUT_ABSENT = "Unexpected exception when applying PUT to purge absent cases for court '%s'";
     private static final String ERR_MSG_FORMAT_PUT_CASE = "Unexpected exception when applying PUT to update case number '%s' for court '%s'.";
     private static final String ERR_MSG_FORMAT_POST_MATCH = "Unexpected exception when POST matches for case number '%s' for court '%s'. Match count was %s";
 
@@ -54,8 +52,6 @@ public class CourtCaseRestClient {
     private String courtCasePutTemplate;
     @Value("${court-case-service.matches-post-url-template}")
     private String matchesPostTemplate;
-    @Value("${court-case-service.purge-absent-put-url-template}")
-    private String purgeAbsentPutTemplate;
     @Value("${court-case-service.probation-status-detail-get-url-template}")
     private String probationStatusDetailGetTemplate;
 
@@ -145,17 +141,6 @@ public class CourtCaseRestClient {
         });
     }
 
-    public void purgeAbsent(String courtCode, Map<LocalDate, List<String>> cases) {
-
-        final String path = String.format(purgeAbsentPutTemplate, courtCode);
-        put(path, cases)
-            .retrieve()
-            .onStatus(HttpStatus::isError, (clientResponse) -> handleError(clientResponse, () -> new CourtNotFoundException(courtCode)))
-            .toBodilessEntity()
-            .doOnError(e -> log.error(String.format(ERR_MSG_FORMAT_PUT_ABSENT, courtCode) + ".Exception : " + e))
-            .subscribe(responseEntity -> log.info("Successful PUT of all cases for purge in court case service for court {}", courtCode));
-    }
-
     public Mono<ProbationStatusDetail> getProbationStatusDetail(String crn) {
         final String path = String.format(probationStatusDetailGetTemplate, crn);
 
@@ -187,15 +172,15 @@ public class CourtCaseRestClient {
         return addSpecAuthAttribute(spec, path);
     }
 
-    private WebClient.RequestHeadersSpec<?> put(String path, Map<LocalDate, List<String>> casesByDate) {
-        var spec = webClient
-            .put()
-            .uri(uriBuilder -> uriBuilder.path(path).build())
-            .body(Mono.just(casesByDate), Map.class)
-            .accept(MediaType.APPLICATION_JSON);
-
-        return addSpecAuthAttribute(spec, path);
-    }
+//    private WebClient.RequestHeadersSpec<?> put(String path, Map<LocalDate, List<String>> casesByDate) {
+//        var spec = webClient
+//            .put()
+//            .uri(uriBuilder -> uriBuilder.path(path).build())
+//            .body(Mono.just(casesByDate), Map.class)
+//            .accept(MediaType.APPLICATION_JSON);
+//
+//        return addSpecAuthAttribute(spec, path);
+//    }
 
     private WebClient.RequestHeadersSpec<?> post(String path, GroupedOffenderMatches request) {
         WebClient.RequestHeadersSpec<?> spec = webClient
@@ -240,18 +225,18 @@ public class CourtCaseRestClient {
             clientResponse.toString().getBytes(),
             StandardCharsets.UTF_8);
     }
-
-    private Mono<? extends Throwable> handleError(ClientResponse clientResponse, Supplier<Throwable> notFoundError) {
-        final HttpStatus httpStatus = clientResponse.statusCode();
-        if (HttpStatus.NOT_FOUND.equals(httpStatus)) {
-            return Mono.error(notFoundError.get());
-        }
-        throw WebClientResponseException.create(httpStatus.value(),
-            httpStatus.name(),
-            clientResponse.headers().asHttpHeaders(),
-            clientResponse.toString().getBytes(),
-            StandardCharsets.UTF_8);
-    }
+//
+//    private Mono<? extends Throwable> handleError(ClientResponse clientResponse, Supplier<Throwable> notFoundError) {
+//        final HttpStatus httpStatus = clientResponse.statusCode();
+//        if (HttpStatus.NOT_FOUND.equals(httpStatus)) {
+//            return Mono.error(notFoundError.get());
+//        }
+//        throw WebClientResponseException.create(httpStatus.value(),
+//            httpStatus.name(),
+//            clientResponse.headers().asHttpHeaders(),
+//            clientResponse.toString().getBytes(),
+//            StandardCharsets.UTF_8);
+//    }
 
     private Mono<Void> logRetrySignal(RetrySignal retrySignal, String messageFormat, String initialError) {
         if (retrySignal.totalRetries() > 0 ) {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseService.java
@@ -12,18 +12,7 @@ import uk.gov.justice.probation.courtcasematcher.model.mapper.MatchDetails;
 import uk.gov.justice.probation.courtcasematcher.model.offendersearch.MatchType;
 import uk.gov.justice.probation.courtcasematcher.restclient.CourtCaseRestClient;
 
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
-
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toList;
 
 @Service
 @Slf4j
@@ -63,17 +52,6 @@ public class CourtCaseService {
         return restClient.getProbationStatusDetail(courtCase.getCrn())
             .map(probationStatusDetail -> CaseMapper.merge(probationStatusDetail, courtCase))
             .switchIfEmpty(Mono.just(courtCase));
-    }
-
-    public void purgeAbsent(String courtCode, Set<LocalDate> hearingDates, List<Case> cases) {
-
-        Map<LocalDate, List<String>> casesByDate = cases.stream()
-            .sorted(Comparator.comparing(Case::getCaseNo))
-            .collect(groupingBy(aCase -> aCase.getBlock().getSession().getDateOfHearing(), TreeMap::new, mapping(Case::getCaseNo, toList())));
-
-        hearingDates.forEach(hearingDate -> casesByDate.putIfAbsent(hearingDate, Collections.emptyList()));
-
-        restClient.purgeAbsent(courtCode, casesByDate);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,6 @@ spring:
 court-case-service:
   case-put-url-template: /court/%s/case/%s
   matches-post-url-template: /court/%s/case/%s/grouped-offender-matches
-  purge-absent-put-url-template: /court/%s/cases/purgeAbsent
   probation-status-detail-get-url-template: /offender/%s/probation-status-detail
   post-max-retries: 3
   min-backoff-seconds: 5

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
@@ -30,20 +30,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @PactDirectory(value = "build/pacts")
 class CourtCaseServiceConsumerPactTest {
 
-    private static final String BASE_MOCK_PATH = "src/test/resources/mocks/__files/get-court-case/";
+    private static final String BASE_MOCK_PATH = "src/test/resources/mocks/__files/";
 
-    private Map<String, String> headers = new HashMap<>(1);
+    private Map<String, String> responseHeaders = new HashMap<>(1);
 
     @BeforeEach
     void beforeAll() {
-        headers = new HashMap<>();
-        headers.put("Content-Type", "application/json");
+        responseHeaders = new HashMap<>();
+        responseHeaders.put("Content-Type", "application/json");
     }
 
     @Pact(provider="court-case-service", consumer="court-case-matcher")
     public RequestResponsePact getCourtCasePact(PactDslWithProvider builder) throws IOException {
 
-        String body = FileUtils.readFileToString(new File(BASE_MOCK_PATH + "GET_court_case_response_1600028913.json"), UTF_8);
+        String body = FileUtils.readFileToString(new File(BASE_MOCK_PATH + "get-court-case/GET_court_case_response_1600028913.json"), UTF_8);
 
         return builder
             .given("a case exists for court B10JQ and case number 1600028913")
@@ -51,7 +51,7 @@ class CourtCaseServiceConsumerPactTest {
             .path("/court/B10JQ/case/1600028913")
             .method("GET")
             .willRespondWith()
-            .headers(headers)
+            .headers(responseHeaders)
             .body(body)
             .status(200)
             .toPact();
@@ -82,23 +82,26 @@ class CourtCaseServiceConsumerPactTest {
             .path("/court/B10JQ/case/1600028914")
             .method("PUT")
             .willRespondWith()
-            .headers(headers)
+            .headers(responseHeaders)
             .status(201)
             .toPact();
     }
 
     @Pact(provider="court-case-service", consumer="court-case-matcher")
-    public RequestResponsePact postGroupedOffenderMatchesPact(PactDslWithProvider builder) {
+    public RequestResponsePact postGroupedOffenderMatchesPact(PactDslWithProvider builder) throws IOException {
 
-        headers.put("Location", "/court/B10JQ/case/1600028913/grouped-offender-matches/1234");
+        String body = FileUtils.readFileToString(new File(BASE_MOCK_PATH + "/post-matches/POST_matches.json"), UTF_8);
+
+        responseHeaders.put("Location", "/court/B10JQ/case/1600028913/grouped-offender-matches/1234");
 
         return builder
             .given("a case does not exist with grouped offender matches")
             .uponReceiving("a request to create grouped offender matches")
+            .body(body)
             .path("/court/B10JQ/case/1600028913/grouped-offender-matches")
             .method("POST")
             .willRespondWith()
-            .headers(headers)
+            .headers(responseHeaders)
             .status(201)
             .toPact();
     }
@@ -120,7 +123,7 @@ class CourtCaseServiceConsumerPactTest {
         var httpResponse = Request
             .Put(mockServer.getUrl() + "/court/B10JQ/case/1600028914")
             .setHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyFile(new File("src/test/resources/mocks/__files/PUT_case_details_body.json"), ContentType.APPLICATION_JSON)
+            .bodyFile(new File(BASE_MOCK_PATH + "PUT_case_details_body.json"), ContentType.APPLICATION_JSON)
             .execute()
             .returnResponse();
 
@@ -132,6 +135,7 @@ class CourtCaseServiceConsumerPactTest {
     void postGroupedOffenderMatches(MockServer mockServer) throws IOException {
         var httpResponse = Request
             .Post(mockServer.getUrl() + "/court/B10JQ/case/1600028913/grouped-offender-matches")
+            .bodyFile(new File(BASE_MOCK_PATH + "/post-matches/POST_matches.json"), ContentType.APPLICATION_JSON)
             .execute()
             .returnResponse();
 

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
@@ -66,7 +66,9 @@ class CourtCaseServiceConsumerPactTest {
             .stringType("title", "forename1", "forename2", "forename3", "surname");
 
         PactDslJsonBody body = new PactDslJsonBody()
-            .stringType("courtCode", "caseId", "caseNo", "courtRoom", "probationStatus", "defendantName", "defendantSex", "crn", "pnc", "cro", "listNo", "nationality1", "nationality2")
+            .stringValue("courtCode", "B10JQ")
+            .stringValue("caseNo", "1600028914")
+            .stringType("caseId", "courtRoom", "probationStatus", "defendantName", "defendantSex", "crn", "pnc", "cro", "listNo", "nationality1", "nationality2")
             .booleanType("suspendedSentenceOrder", "breach", "preSentenceActivity")
             .date("previouslyKnownTerminationDate","yyyy-MM-dd")
             .date("defendantDob","yyyy-MM-dd")

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
@@ -66,8 +66,11 @@ class CourtCaseServiceConsumerPactTest {
             .stringType("title", "forename1", "forename2", "forename3", "surname");
 
         PactDslJsonBody body = new PactDslJsonBody()
-            .stringType("courtCode", "caseId", "caseNo", "courtRoom", "sessionStartTime", "probationStatus", "previouslyKnownTerminationDate", "defendantName", "defendantDob", "defendantSex", "defendantType", "crn", "pnc", "cro", "listNo", "nationality1", "nationality2")
+            .stringType("courtCode", "caseId", "caseNo", "courtRoom", "probationStatus", "defendantName", "defendantSex", "defendantType", "crn", "pnc", "cro", "listNo", "nationality1", "nationality2")
             .booleanType("suspendedSentenceOrder", "breach", "preSentenceActivity")
+            .date("previouslyKnownTerminationDate","yyyy-MM-dd")
+            .date("defendantDob","yyyy-MM-dd")
+            .datetime("sessionStartTime")
             .object("defendantAddress", addressPart)
             .object("name", namePart)
             .eachLike("offences")

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
@@ -66,11 +66,12 @@ class CourtCaseServiceConsumerPactTest {
             .stringType("title", "forename1", "forename2", "forename3", "surname");
 
         PactDslJsonBody body = new PactDslJsonBody()
-            .stringType("courtCode", "caseId", "caseNo", "courtRoom", "probationStatus", "defendantName", "defendantSex", "defendantType", "crn", "pnc", "cro", "listNo", "nationality1", "nationality2")
+            .stringType("courtCode", "caseId", "caseNo", "courtRoom", "probationStatus", "defendantName", "defendantSex", "crn", "pnc", "cro", "listNo", "nationality1", "nationality2")
             .booleanType("suspendedSentenceOrder", "breach", "preSentenceActivity")
             .date("previouslyKnownTerminationDate","yyyy-MM-dd")
             .date("defendantDob","yyyy-MM-dd")
             .datetime("sessionStartTime")
+            .stringValue("defendantType", "PERSON")
             .object("defendantAddress", addressPart)
             .object("name", namePart)
             .eachLike("offences")

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/pact/CourtCaseServiceConsumerPactTest.java
@@ -1,0 +1,142 @@
+package uk.gov.justice.probation.courtcasematcher.pact;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.annotations.PactDirectory;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "court-case-service")
+@PactDirectory(value = "build/pacts")
+class CourtCaseServiceConsumerPactTest {
+
+    private static final String BASE_MOCK_PATH = "src/test/resources/mocks/__files/get-court-case/";
+
+    private Map<String, String> headers = new HashMap<>(1);
+
+    @BeforeEach
+    void beforeAll() {
+        headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+    }
+
+    @Pact(provider="court-case-service", consumer="court-case-matcher")
+    public RequestResponsePact getCourtCasePact(PactDslWithProvider builder) throws IOException {
+
+        String body = FileUtils.readFileToString(new File(BASE_MOCK_PATH + "GET_court_case_response_1600028913.json"), UTF_8);
+
+        return builder
+            .given("a case exists for court B10JQ and case number 1600028913")
+            .uponReceiving("a request for a case by case number")
+            .path("/court/B10JQ/case/1600028913")
+            .method("GET")
+            .willRespondWith()
+            .headers(headers)
+            .body(body)
+            .status(200)
+            .toPact();
+    }
+
+    @Pact(provider="court-case-service", consumer="court-case-matcher")
+    public RequestResponsePact putCourtCasePact(PactDslWithProvider builder) {
+
+        PactDslJsonBody addressPart = new PactDslJsonBody()
+            .stringType("line1", "line2", "line3", "line4", "line5", "postcode");
+        PactDslJsonBody namePart = new PactDslJsonBody()
+            .stringType("title", "forename1", "forename2", "forename3", "surname");
+
+        PactDslJsonBody body = new PactDslJsonBody()
+            .stringType("courtCode", "caseId", "caseNo", "courtRoom", "sessionStartTime", "probationStatus", "previouslyKnownTerminationDate", "defendantName", "defendantDob", "defendantSex", "defendantType", "crn", "pnc", "cro", "listNo", "nationality1", "nationality2")
+            .booleanType("suspendedSentenceOrder", "breach", "preSentenceActivity")
+            .object("defendantAddress", addressPart)
+            .object("name", namePart)
+            .eachLike("offences")
+                .stringType("offenceTitle","offenceSummary", "act")
+            ;
+
+        return builder
+            .given("a case does not exist for court B10JQ and case number 1600028914")
+            .uponReceiving("a request to save a new case")
+            .body(body)
+            .headers("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .path("/court/B10JQ/case/1600028914")
+            .method("PUT")
+            .willRespondWith()
+            .headers(headers)
+            .status(201)
+            .toPact();
+    }
+
+    @Pact(provider="court-case-service", consumer="court-case-matcher")
+    public RequestResponsePact postGroupedOffenderMatchesPact(PactDslWithProvider builder) {
+
+        headers.put("Location", "/court/B10JQ/case/1600028913/grouped-offender-matches/1234");
+
+        return builder
+            .given("a case does not exist with grouped offender matches")
+            .uponReceiving("a request to create grouped offender matches")
+            .path("/court/B10JQ/case/1600028913/grouped-offender-matches")
+            .method("POST")
+            .willRespondWith()
+            .headers(headers)
+            .status(201)
+            .toPact();
+    }
+
+    @PactTestFor(pactMethod = "getCourtCasePact")
+    @Test
+    void getCourtCase(MockServer mockServer) throws IOException {
+        var httpResponse = Request
+            .Get(mockServer.getUrl() + "/court/B10JQ/case/1600028913")
+            .execute()
+            .returnResponse();
+
+        assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+    }
+
+    @PactTestFor(pactMethod = "putCourtCasePact")
+    @Test
+    void putCourtCase(MockServer mockServer) throws IOException {
+        var httpResponse = Request
+            .Put(mockServer.getUrl() + "/court/B10JQ/case/1600028914")
+            .setHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
+            .bodyFile(new File("src/test/resources/mocks/__files/PUT_case_details_body.json"), ContentType.APPLICATION_JSON)
+            .execute()
+            .returnResponse();
+
+        assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @PactTestFor(pactMethod = "postGroupedOffenderMatchesPact")
+    @Test
+    void postGroupedOffenderMatches(MockServer mockServer) throws IOException {
+        var httpResponse = Request
+            .Post(mockServer.getUrl() + "/court/B10JQ/case/1600028913/grouped-offender-matches")
+            .execute()
+            .returnResponse();
+
+        assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.CREATED.value());
+        var locationHeader = Arrays.stream(httpResponse.getHeaders("Location")).findFirst();
+        assertThat(locationHeader.get().getValue()).isEqualTo("/court/B10JQ/case/1600028913/grouped-offender-matches/1234");
+    }
+}

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/CourtCaseServiceTest.java
@@ -20,11 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.Month;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,46 +41,6 @@ class CourtCaseServiceTest {
 
     @InjectMocks
     private CourtCaseService courtCaseService;
-
-    @DisplayName("Purge with 5 cases across 4 sessions and 2 days")
-    @Test
-    void purgeAbsent() {
-
-        Session sessionJan1a = Session.builder().dateOfHearing(JAN_1).courtCode(COURT_CODE).build();
-        Session sessionJan1b = Session.builder().dateOfHearing(JAN_1).courtCode(COURT_CODE).build();
-
-        Session sessionJan3a = Session.builder().dateOfHearing(JAN_3).courtCode(COURT_CODE).build();
-        Session sessionJan3b = Session.builder().dateOfHearing(JAN_3).courtCode(COURT_CODE).build();
-
-        Case aCase10 = Case.builder().caseNo("1010").block(Block.builder().session(sessionJan1a).build()).build();
-        Case aCase20 = Case.builder().caseNo("1011").block(Block.builder().session(sessionJan1b).build()).build();
-        Case aCase21 = Case.builder().caseNo("1030").block(Block.builder().session(sessionJan3a).build()).build();
-        Case aCase30 = Case.builder().caseNo("1031").block(Block.builder().session(sessionJan3a).build()).build();
-        Case aCase31 = Case.builder().caseNo("1032").block(Block.builder().session(sessionJan3b).build()).build();
-
-        List<Case> allCases = asList(aCase20, aCase21, aCase10, aCase30, aCase31);
-
-        courtCaseService.purgeAbsent(COURT_CODE, Set.of(JAN_1, JAN_3), allCases);
-
-        Map<LocalDate, List<String>> expected = Map.of(JAN_1, asList("1010", "1011"), JAN_3, asList("1030", "1031", "1032"));
-        verify(restClient).purgeAbsent(COURT_CODE, expected);
-    }
-
-    @DisplayName("Purge with 2 cases across 1 sessions and 2 days. One day has no cases.")
-    @Test
-    void purgeAbsentNoCases() {
-
-
-        Session sessionJan3 = Session.builder().dateOfHearing(JAN_3).courtCode(COURT_CODE).build();
-
-        Case aCase30 = Case.builder().caseNo("1031").block(Block.builder().session(sessionJan3).build()).build();
-        Case aCase31 = Case.builder().caseNo("1032").block(Block.builder().session(sessionJan3).build()).build();
-
-        courtCaseService.purgeAbsent(COURT_CODE, Set.of(JAN_1, JAN_3), asList(aCase30, aCase31));
-
-        Map<LocalDate, List<String>> expected = Map.of(JAN_1, Collections.emptyList(), JAN_3, asList("1031", "1032"));
-        verify(restClient).purgeAbsent(COURT_CODE, expected);
-    }
 
     @DisplayName("Save court case.")
     @Test

--- a/src/test/resources/mocks/__files/PUT_case_details_body.json
+++ b/src/test/resources/mocks/__files/PUT_case_details_body.json
@@ -1,33 +1,49 @@
 {
-  "lastUpdated": "2020-06-06T17:32:00.490478",
   "caseId": "1246257",
-  "caseNo": "12345",
-  "crn": "X320741",
-  "pnc": "D/1234560BC",
-  "listNo": "2nd",
-  "courtCode": "SHF",
+  "caseNo": "1600032981",
+  "courtCode": "B10JQ",
   "courtRoom": "1",
   "sessionStartTime": "2020-01-13T09:00:00",
-  "session": "MORNING",
-  "probationStatus": "Current",
+  "probationStatus": "CURRENT",
+  "previouslyKnownTerminationDate": "2020-10-10",
   "suspendedSentenceOrder": true,
   "breach": true,
-  "offences": [],
-  "defendantName": "Mr Dylan Adam ARMSTRONG",
+  "preSentenceActivity": false,
+  "offences": [
+    {
+      "offenceTitle": "Theft from a shop",
+      "offenceSummary": "On 01/01/2016 at Town, stole Article, to the value of £100.00, belonging to Person.",
+      "act": "Contrary to section 1(1) and 7 of the Theft Act 1968."
+    },
+    {
+      "offenceTitle": "Drunk and disorderly",
+      "offenceSummary": "Walking down the street singing offensive songs offensively.",
+      "act": "Contrary to public decency."
+    }
+  ],
   "name": {
     "title": "Mr",
     "forename1": "Dylan",
     "forename2": "Adam",
+    "forename3": "Alex",
     "surname": "ARMSTRONG"
   },
+  "defendantName": "Mr Dylan Adam Alex ARMSTRONG",
   "defendantAddress": {
     "line1": "27",
     "line2": "Elm Place",
-    "postcode": "ad21 5dr",
-    "line3": "Bangor"
+    "line3": "Bangor",
+    "line4": "Gwynedd",
+    "line5": "WALES",
+    "postcode": "ad21 5dr"
   },
   "defendantDob": "1977-12-11",
   "defendantSex": "M",
   "defendantType": "PERSON",
-  "nationality1": "British"
+  "crn": "X320741",
+  "pnc": "D/1234560BC",
+  "cro": "34560BC",
+  "listNo": "2nd",
+  "nationality1": "British",
+  "nationality2": "Polish"
 }

--- a/src/test/resources/mocks/__files/PUT_case_details_body.json
+++ b/src/test/resources/mocks/__files/PUT_case_details_body.json
@@ -1,6 +1,6 @@
 {
   "caseId": "1246257",
-  "caseNo": "1600032981",
+  "caseNo": "1600028914",
   "courtCode": "B10JQ",
   "courtRoom": "1",
   "sessionStartTime": "2020-01-13T09:00:00",

--- a/src/test/resources/mocks/__files/get-court-case/GET_court_case_response_1600028913.json
+++ b/src/test/resources/mocks/__files/get-court-case/GET_court_case_response_1600028913.json
@@ -1,0 +1,11 @@
+{
+  "caseNo": "1600028913",
+  "courtCode": "B10JQ",
+  "pnc": "A/1234560BA",
+  "probationStatusActual": "CURRENT",
+  "previouslyKnownTerminationDate": "2010-01-01",
+  "crn": "X340741",
+  "suspendedSentenceOrder": true,
+  "breach": true,
+  "preSentenceActivity": true
+}

--- a/src/test/resources/mocks/__files/post-matches/POST_matches.json
+++ b/src/test/resources/mocks/__files/post-matches/POST_matches.json
@@ -1,0 +1,20 @@
+{
+  "matches": [
+    {
+      "matchIdentifiers": {
+        "crn": "X12345"
+      },
+      "matchType": "PARTIAL_NAME",
+      "confirmed": false,
+      "rejected": true
+    },
+    {
+      "matchIdentifiers": {
+        "crn": "X12346"
+      },
+      "matchType": "NAME_DOB_ALIAS",
+      "confirmed": true,
+      "rejected": false
+    }
+  ]
+}


### PR DESCRIPTION
Added PACT tests for - 

1. getCourtCase, the PACT only enforces the fields that are used from the CourtCaseResponse. So for example, the getCourtCase call has no interest in offences, nationality, because these values get updated with each Libra feed for the case.
2. PUT court case - uses matchers for assertions on the body of the PUT request. The interaction that the provider will verify may be a bit easier to implement. There is no interest in the response and no verification on that.
3. POST grouped offender matches - uses a literal JSON string for the assertion on the body of the POST request. There is no interest in the response and no verification on that. However, the "Location" in the response header is read and logged.

Also took the opportunity to remove the methods related to purging of cases. These have been unused for some time. 