### PR TITLE
✨ PIC-1331 fix env vars so that the service starts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
+  PROCESS_COURT_CASE_MATCHER_MESSAGES: false
 
 spring:
   profile: dev,sqs-messaging,instrumented

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,6 +20,7 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
+  PROCESS_COURT_CASE_MATCHER_MESSAGES: false
 
 spring:
   profile: preprod,sqs-messaging,instrumented

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,6 +21,7 @@ ingress:
 
 env:
   JAVA_OPTS: "-Xmx512m"
+  PROCESS_COURT_CASE_MATCHER_MESSAGES: false
 
 spring:
   profile: prod,sqs-messaging,instrumented


### PR DESCRIPTION
The error in logs was 
```org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'sqsMessageReceiver': Unsatisfied dependency expressed through field 'processCourtCaseMatcherMessages'; nested exception is org.springframework.beans.TypeMismatchException: Failed to convert value of type 'java.lang.String' to required type 'boolean'; nested exception is java.lang.IllegalArgumentException: Invalid boolean value []```

There is now a boolean in the helm environment files. 