### PR TITLE
✨️ PIC-1689: Add validation for CommonPlatformHearing

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Address.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Address.java
@@ -6,11 +6,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class Address {
+    @NotBlank
     private final String address1;
     private final String address2;
     private final String address3;

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/CommonPlatformHearing.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/CommonPlatformHearing.java
@@ -7,6 +7,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.justice.probation.courtcasematcher.model.domain.CourtCase;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
@@ -14,10 +17,18 @@ import java.util.List;
 @NoArgsConstructor(access=AccessLevel.PRIVATE, force = true)
 @AllArgsConstructor
 public class CommonPlatformHearing {
+    @NotBlank
     private final String id;
+    @NotNull
+    @Valid
     private final CourtCentre courtCentre;
+    @NotNull
+    @Valid
     private final List<HearingDay> hearingDays;
+    @NotNull
     private final JurisdictionType jurisdictionType;
+    @NotNull
+    @Valid
     private final List<ProsecutionCase> prosecutionCases;
 
     public CourtCase asDomain() {

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/CommonPlatformHearing.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/CommonPlatformHearing.java
@@ -9,6 +9,7 @@ import uk.gov.justice.probation.courtcasematcher.model.domain.CourtCase;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
@@ -22,12 +23,12 @@ public class CommonPlatformHearing {
     @NotNull
     @Valid
     private final CourtCentre courtCentre;
-    @NotNull
+    @NotEmpty
     @Valid
     private final List<HearingDay> hearingDays;
     @NotNull
     private final JurisdictionType jurisdictionType;
-    @NotNull
+    @NotEmpty
     @Valid
     private final List<ProsecutionCase> prosecutionCases;
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/CourtCentre.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/CourtCentre.java
@@ -6,13 +6,19 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Data
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 @AllArgsConstructor
 public class CourtCentre {
+    @NotBlank
     private final String id;
+    @NotBlank
     private final String roomId;
+    @NotBlank
     private final String roomName;
+    @NotBlank
     private final String code;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Defendant.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Defendant.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
@@ -13,11 +16,17 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class Defendant {
+    @NotBlank
     private final String id;
     private final String pncId;
     private final String croNumber;
+    @NotBlank
     private final String prosecutionCaseId;
+    @NotNull
+    @Valid
     private final List<Offence> offences;
+    @Valid
     private final PersonDefendant personDefendant;
+    @Valid
     private final LegalEntityDefendant legalEntityDefendant;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/HearingDay.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/HearingDay.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Data
@@ -13,7 +14,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class HearingDay {
+    @NotNull
     private final Integer listedDurationMinutes;
     private final Integer listingSequence;
+    @NotNull
     private final LocalDateTime sittingDay;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/LegalEntityDefendant.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/LegalEntityDefendant.java
@@ -6,10 +6,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class LegalEntityDefendant {
+    @NotNull
+    @Valid
     private final Organisation organisation;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Offence.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Offence.java
@@ -6,13 +6,19 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class Offence {
+    @NotBlank
     private final String id;
+    @NotBlank
     private final String offenceLegislation;
+    @NotBlank
     private final String offenceTitle;
+    @NotBlank
     private final String wording;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Organisation.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/Organisation.java
@@ -6,10 +6,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class Organisation {
+    @NotBlank
     private final String name;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/PersonDefendant.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/PersonDefendant.java
@@ -6,10 +6,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class PersonDefendant {
+    @NotNull
+    @Valid
     private final PersonDetails personDetails;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/PersonDetails.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/PersonDetails.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Data
@@ -21,7 +20,6 @@ public class PersonDetails {
     private final String middleName;
     @NotBlank
     private final String lastName;
-    @NotNull
     private final LocalDate dateOfBirth;
     @NotBlank
     private final String gender;

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/PersonDetails.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/PersonDetails.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 @Data
@@ -16,8 +19,12 @@ public class PersonDetails {
     private final String title;
     private final String firstName;
     private final String middleName;
+    @NotBlank
     private final String lastName;
+    @NotNull
     private final LocalDate dateOfBirth;
+    @NotBlank
     private final String gender;
+    @Valid
     private final Address address;
 }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/ProsecutionCase.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/model/commonplatform/ProsecutionCase.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
@@ -13,6 +16,9 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class ProsecutionCase {
+    @NotBlank
     private final String id;
+    @NotNull
+    @Valid
     private final List<Defendant> defendants;
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageParserTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/MessageParserTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.probation.courtcasematcher.messaging;
 
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import uk.gov.justice.probation.courtcasematcher.messaging.model.libra.LibraCase
 import uk.gov.justice.probation.courtcasematcher.messaging.model.libra.LibraName;
 import uk.gov.justice.probation.courtcasematcher.messaging.model.libra.LibraOffence;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,6 +38,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
 import java.util.List;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -77,6 +80,31 @@ class MessageParserTest {
             checkHearing(aHearing, List.of(defendant1(), legalEntityDefendant()));
         }
 
+        @Test
+        void whenInvalidCase_ThenThrow() throws IOException {
+            var path = "src/test/resources/messages/common-platform/hearing-invalid.json";
+            var content = Files.readString(Paths.get(path));
+
+            var thrown = catchThrowable(() -> messageParser.parseMessage(content, CommonPlatformHearing.class));
+
+            var ex = (ConstraintViolationException) thrown;
+            assertThat(ex.getConstraintViolations()).hasSize(9);
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("courtCentre.roomName", "must not be blank"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("hearingDays[0].sittingDay", "must not be null"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("jurisdictionType", "must not be null"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("prosecutionCases[0].id", "must not be blank"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("prosecutionCases[0].defendants[0].id", "must not be blank"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("prosecutionCases[0].defendants[0].offences[0].wording", "must not be blank"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("prosecutionCases[0].defendants[0].personDefendant.personDetails.lastName", "must not be blank"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("prosecutionCases[0].defendants[0].personDefendant.personDetails.address.address1", "must not be blank"));
+            assertThat(ex.getConstraintViolations()).anyMatch(validationError("prosecutionCases[0].defendants[1].legalEntityDefendant.organisation.name", "must not be blank"));
+        }
+
+        private Predicate<ConstraintViolation<?>> validationError(String path, String message) {
+            return cv -> cv.getMessage().equals(message)
+                    && cv.getPropertyPath().toString().equals(path);
+        }
+
         private void checkHearing(CommonPlatformHearing actual, List<Defendant> defendants) {
             assertThat(actual).isNotNull();
             assertThat(actual.getId()).isEqualTo("8bbb4fe3-a899-45c7-bdd4-4ee25ac5a83f");
@@ -116,13 +144,13 @@ class MessageParserTest {
                     .pncId(null)
                     .croNumber(null)
                     .offences(List.of(Offence.builder()
-                                    .id(null)
+                                    .id("50474F6F-65FC-48C7-AA83-16277B55B3BA")
                                     .offenceLegislation("Contrary to section 20 of the Offences Against the    Person Act 1861.")
                                     .offenceTitle("Wound / inflict grievous bodily harm without intent")
                                     .wording("on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith")
                                     .build(),
                             Offence.builder()
-                                    .id(null)
+                                    .id("7103C6BD-5805-4EF8-B524-D34B9ADD43D1")
                                     .offenceLegislation("Contrary to section 20 of the Offences Against the    Person Act 1861.")
                                     .offenceTitle("Wound / inflict grievous bodily harm without intent")
                                     .wording("on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith")
@@ -182,13 +210,13 @@ class MessageParserTest {
                     .pncId(null)
                     .croNumber(null)
                     .offences(List.of(Offence.builder()
-                                    .id(null)
+                                    .id("1391ADC2-7A43-48DC-8523-3D28B9DCD2B7")
                                     .offenceLegislation("Contrary to section 20 of the Offences Against the    Person Act 1861.")
                                     .offenceTitle("Wound / inflict grievous bodily harm without intent")
                                     .wording("on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith")
                                     .build(),
                             Offence.builder()
-                                    .id(null)
+                                    .id("19C08FB0-363B-4EB1-938D-76EF751E5D66")
                                     .offenceLegislation("Contrary to section 20 of the Offences Against the    Person Act 1861.")
                                     .offenceTitle("Wound / inflict grievous bodily harm without intent")
                                     .wording("on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith")

--- a/src/test/resources/messages/common-platform/hearing-invalid.json
+++ b/src/test/resources/messages/common-platform/hearing-invalid.json
@@ -2,15 +2,13 @@
   "courtCentre": {
     "id": "9b583616-049b-30f9-a14f-028a53b7cfe8",
     "roomId": "7cb09222-49e1-3622-a5a6-ad253d2b3c39",
-    "roomName": "Crown Court 3-1",
     "code": "B10JQ00"
   },
   "hearingDays": [
     {
       "listedDurationMinutes": 60,
-      "listingSequence": 0,
-      "sittingDay": "2021-09-08T09:00:00.000Z"
-    } ,
+      "listingSequence": 0
+    },
     {
       "listedDurationMinutes": 30,
       "listingSequence": 1,
@@ -18,12 +16,10 @@
     }
   ],
   "id": "8bbb4fe3-a899-45c7-bdd4-4ee25ac5a83f",
-  "jurisdictionType": "CROWN",
   "prosecutionCases": [
     {
       "defendants": [
         {
-          "id": "0ab7c3e5-eb4c-4e3f-b9e6-b9e78d3ea199",
           "pncId": "2004/0012345U",
           "croNumber": "12345ABCDEF",
           "offences": [
@@ -31,7 +27,7 @@
               "id": "a63d9020-aa6b-4997-92fd-72a692b036de",
               "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
               "offenceTitle": "Wound / inflict grievous bodily harm without intent",
-              "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
+              "wording": ""
             },
             {
               "id": "ea1c2cf1-f155-483b-a908-81158a9b2f9b",
@@ -43,7 +39,6 @@
           "personDefendant": {
             "personDetails": {
               "address": {
-                "address1": "13 Wind Street",
                 "address2": "Swansea",
                 "address3": "Wales",
                 "address4": "UK",
@@ -51,10 +46,9 @@
                 "postcode": "SA1 1FU"
               },
               "dateOfBirth": "1983-02-28",
-              "firstName": "Norbert",
+              "firstName": "Mario",
               "middleName": "Forester",
               "gender": "MALE",
-              "lastName": "McCullough",
               "title": "Mr"
             }
           },
@@ -64,13 +58,13 @@
           "id": "903c4c54-f667-4770-8fdf-1adbb5957c25",
           "offences": [
             {
-              "id": "50474F6F-65FC-48C7-AA83-16277B55B3BA",
+              "id": "1391ADC2-7A43-48DC-8523-3D28B9DCD2B7",
               "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
               "offenceTitle": "Wound / inflict grievous bodily harm without intent",
               "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
             },
             {
-              "id": "7103C6BD-5805-4EF8-B524-D34B9ADD43D1",
+              "id": "19C08FB0-363B-4EB1-938D-76EF751E5D66",
               "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
               "offenceTitle": "Wound / inflict grievous bodily harm without intent",
               "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith"
@@ -78,13 +72,13 @@
           ],
           "legalEntityDefendant": {
             "organisation": {
-              "name": "An Organisation"
+              "name": ""
             }
           },
           "prosecutionCaseId": "b7417f11-49d8-482d-b516-ba4135d38d0d"
         }
       ],
-      "id": "b7417f11-49d8-482d-b516-ba4135d38d0d"
+      "id": ""
     }
   ]
 }

--- a/src/test/resources/messages/common-platform/hearing.json
+++ b/src/test/resources/messages/common-platform/hearing.json
@@ -64,11 +64,13 @@
           "id": "903c4c54-f667-4770-8fdf-1adbb5957c25",
           "offences": [
             {
+              "id": "1391ADC2-7A43-48DC-8523-3D28B9DCD2B7",
               "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
               "offenceTitle": "Wound / inflict grievous bodily harm without intent",
               "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
             },
             {
+              "id": "19C08FB0-363B-4EB1-938D-76EF751E5D66",
               "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
               "offenceTitle": "Wound / inflict grievous bodily harm without intent",
               "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith"


### PR DESCRIPTION
Just validation on this one. 

I've been reasonably strict in terms of what's required and what's not on the basis that the tighter our constraints  can be without breaking under use, the more easily we can reason about the data we're receiving. If validation fails when we start integration testing with CP then a) we've learned something and b) it's trivial to relax any constraints that aren't strictly needed.

Anything marked as required in the schema is obviously mandatory. In addition to this anything that is required or expected in the court-case-service is required. I've also made all ids @NotBlank on the basis that they *should* always be present and if we hang on to these for future use then we will probably need them to be present.