### PR TITLE
🔊 PIC-2477: Emit processing failure telemetry events

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/HearingProcessor.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/messaging/HearingProcessor.java
@@ -9,8 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
-import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.model.domain.DataSource;
+import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.model.mapper.HearingMapper;
 import uk.gov.justice.probation.courtcasematcher.service.CourtCaseService;
 import uk.gov.justice.probation.courtcasematcher.service.MatcherService;
@@ -46,6 +46,7 @@ public class HearingProcessor {
             matchAndSaveHearing(receivedHearing, messageId);
         } catch (Exception ex) {
             log.error("Message processing failed. Error: {} ", ex.getMessage(), ex);
+            telemetryService.trackProcessingFailureEvent(receivedHearing);
             throw new RuntimeException(ex.getMessage(), ex);
         }
     }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryEventType.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryEventType.java
@@ -10,8 +10,8 @@ public enum TelemetryEventType {
     COURT_LIST_MESSAGE_RECEIVED("PiCCourtListMessageReceived"),
     HEARING_RECEIVED("PiCHearingReceived"),
     HEARING_CHANGED("PiCHearingChanged"),
-    HEARING_UNCHANGED("PiCHearingUnchanged")
-    ;
+    HEARING_UNCHANGED("PiCHearingUnchanged"),
+    PROCESSING_FAILURE("PiCMatcherProcessingFailure");
 
     final String eventName;
 

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryService.java
@@ -3,8 +3,8 @@ package uk.gov.justice.probation.courtcasematcher.service;
 import com.microsoft.applicationinsights.TelemetryClient;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.model.domain.Defendant;
+import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.restclient.model.offendersearch.MatchResponse;
 
 import java.time.format.DateTimeFormatter;
@@ -152,5 +152,10 @@ public class TelemetryService {
     public AutoCloseable withOperation(String operationId) {
         telemetryClient.getContext().getOperation().setId(operationId);
         return () -> telemetryClient.getContext().getOperation().setId(null);
+    }
+
+    public void trackProcessingFailureEvent(Hearing hearing) {
+        final var properties = getHearingProperties(hearing);
+        telemetryClient.trackEvent(TelemetryEventType.PROCESSING_FAILURE.eventName, properties, Collections.emptyMap());
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/HearingProcessorTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/messaging/HearingProcessorTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
-import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.model.domain.Defendant;
+import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.model.domain.HearingDay;
 import uk.gov.justice.probation.courtcasematcher.model.mapper.HearingMapper;
 import uk.gov.justice.probation.courtcasematcher.service.CourtCaseService;
@@ -21,7 +21,11 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static uk.gov.justice.probation.courtcasematcher.model.type.DefendantType.PERSON;
 
 @ExtendWith(MockitoExtension.class)
@@ -202,6 +206,8 @@ class HearingProcessorTest {
 
     @Test
     void givenNullCourtCase_thenThrowRuntimeException() {
-        assertThrows(RuntimeException.class, () -> messageProcessor.process(null, MESSAGE_ID));
+        var hearing = Hearing.builder().build();
+        assertThrows(RuntimeException.class, () -> messageProcessor.process(hearing, MESSAGE_ID));
+        verify(telemetryService, times(1)).trackProcessingFailureEvent(hearing);
     }
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/TelemetryServiceTest.java
@@ -13,9 +13,9 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.model.domain.DataSource;
 import uk.gov.justice.probation.courtcasematcher.model.domain.Defendant;
+import uk.gov.justice.probation.courtcasematcher.model.domain.Hearing;
 import uk.gov.justice.probation.courtcasematcher.model.domain.HearingDay;
 import uk.gov.justice.probation.courtcasematcher.restclient.model.offendersearch.Match;
 import uk.gov.justice.probation.courtcasematcher.restclient.model.offendersearch.MatchResponse;
@@ -317,6 +317,15 @@ class TelemetryServiceTest {
         telemetryService.trackHearingUnChangedEvent(hearing);
 
         verify(telemetryClient).trackEvent(eq("PiCHearingUnchanged"), propertiesCaptor.capture(), eq(Collections.emptyMap()));
+
+        assertHearingProperties();
+    }
+
+    @Test
+    void whenProcessingFails_thenRecord() {
+        telemetryService.trackProcessingFailureEvent(hearing);
+
+        verify(telemetryClient).trackEvent(eq("PiCMatcherProcessingFailure"), propertiesCaptor.capture(), eq(Collections.emptyMap()));
 
         assertHearingProperties();
     }

--- a/src/test/resources/mocks/mappings/post-matches/POST_match_by_case_and_defendant_id.json
+++ b/src/test/resources/mocks/mappings/post-matches/POST_match_by_case_and_defendant_id.json
@@ -4,7 +4,7 @@
     "url": "/defendant/0ab7c3e5-eb4c-4e3f-b9e6-b9e78d3ea199/grouped-offender-matches",
     "bodyPatterns": [
       {
-        "matches" : ".*X123456.*"
+        "matches" : ".*X346204.*"
       }
     ]
   },

--- a/src/test/resources/mocks/mappings/post-matches/POST_match_by_case_and_defendant_id_any_other.json
+++ b/src/test/resources/mocks/mappings/post-matches/POST_match_by_case_and_defendant_id_any_other.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/defendant/[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}/grouped-offender-matches"
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
The main reason for this change is to fix a number of integration tests which were erroneously passing when exceptions being thrown. It will prevent future cases of this and as a bonus allows better visibility of processing errors in AppInsights