### PR TITLE
PIC-3280 Add IRSA service account to k8s manifest

### DIFF
--- a/helm_deploy/court-case-matcher/templates/deployment.yaml
+++ b/helm_deploy/court-case-matcher/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         app: {{ template "app.name" . }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: court-case-service
       containers:
         - name: court-case-matcher
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
CCM sits within the court-probation-xxx k8s namespace