### PR TITLE
PIC-4008 add prometheus alerting on SQS

### DIFF
--- a/helm_deploy/court-case-matcher/Chart.yaml
+++ b/helm_deploy/court-case-matcher/Chart.yaml
@@ -3,8 +3,4 @@ appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: court-case-matcher
 version: 0.2.0
-dependencies:
-  - name: generic-prometheus-alerts
-    version: 1.9.0
-    repository: https://ministryofjustice.github.io/hmpps-helm-charts
 

--- a/helm_deploy/court-case-matcher/Chart.yaml
+++ b/helm_deploy/court-case-matcher/Chart.yaml
@@ -2,4 +2,9 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: court-case-matcher
-version: 0.1.0
+version: 0.2.0
+dependencies:
+  - name: generic-prometheus-alerts
+    version: 1.9.0
+    repository: https://ministryofjustice.github.io/hmpps-helm-charts
+

--- a/helm_deploy/court-case-matcher/templates/requirements.yaml
+++ b/helm_deploy/court-case-matcher/templates/requirements.yaml
@@ -1,4 +1,6 @@
+metadata:
+  name: "generic-prometheus-alerts"
 dependencies:
-  - name: generic-prometheus-alerts
+  - name: "generic-prometheus-alerts"
     version: 1.9.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/court-case-matcher/templates/requirements.yaml
+++ b/helm_deploy/court-case-matcher/templates/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: generic-prometheus-alerts
+    version: 1.9.0
+    repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -35,7 +35,7 @@ resources:
 
 generic-prometheus-alerts:
   targetApplication: court-case-matcher
-  alertSeverity: slack-hmpps-user-preferences
+  alertSeverity: probation_in_court_alerts_dev
   businessHoursOnly: true
   sqsNumberAlertQueueNames:
     - "probation-in-court-team-development-court-case-matcher-queue"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,3 +32,12 @@ resources:
   memory:
     limit: 1200Mi
     request: 350Mi
+
+generic-prometheus-alerts:
+  targetApplication: court-case-matcher
+  alertSeverity: slack-hmpps-user-preferences
+  businessHoursOnly: true
+  sqsNumberAlertQueueNames:
+    - "probation-in-court-team-development-court-case-matcher-queue"
+    - "probation-in-court-team-development-court-case-matcher-dead-letter-queue"
+  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -32,3 +32,12 @@ resources:
   memory:
     limit: 2Gi
     request: 1Gi
+
+generic-prometheus-alerts:
+  targetApplication: court-case-matcher
+  alertSeverity: slack-hmpps-user-preferences
+  businessHoursOnly: true
+  sqsNumberAlertQueueNames:
+    - "probation-in-court-team-preprod-court-case-matcher-queue"
+    - "probation-in-court-team-preprod-court-case-matcher-dead-letter-queue"
+  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -35,7 +35,7 @@ resources:
 
 generic-prometheus-alerts:
   targetApplication: court-case-matcher
-  alertSeverity: slack-hmpps-user-preferences
+  alertSeverity: probation_in_court_alerts_preprod
   businessHoursOnly: true
   sqsNumberAlertQueueNames:
     - "probation-in-court-team-preprod-court-case-matcher-queue"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -33,3 +33,11 @@ resources:
   memory:
     limit: 2Gi
     request: 1Gi
+
+generic-prometheus-alerts:
+  targetApplication: court-case-matcher
+  alertSeverity: slack-hmpps-user-preferences
+  sqsNumberAlertQueueNames:
+    - "probation-in-court-prod-court-case-matcher-queue"
+    - "probation-in-court-prod-court-case-matcher-dead-letter-queue"
+  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -36,7 +36,7 @@ resources:
 
 generic-prometheus-alerts:
   targetApplication: court-case-matcher
-  alertSeverity: slack-hmpps-user-preferences
+  alertSeverity: probation_in_court_alerts_prod
   sqsNumberAlertQueueNames:
     - "probation-in-court-prod-court-case-matcher-queue"
     - "probation-in-court-prod-court-case-matcher-dead-letter-queue"


### PR DESCRIPTION
This was significantly complicated by the fact that this service is on helm v1, and does not already have alerting or the generic service set up.
