### PR TITLE
Revert "PIC-4008 add prometheus alerting on SQS (#629)"

### DIFF
--- a/helm_deploy/court-case-matcher/Chart.yaml
+++ b/helm_deploy/court-case-matcher/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: court-case-matcher
-version: 0.2.0
-
+version: 0.1.0

--- a/helm_deploy/court-case-matcher/templates/requirements.yaml
+++ b/helm_deploy/court-case-matcher/templates/requirements.yaml
@@ -1,6 +1,0 @@
-metadata:
-  name: "generic-prometheus-alerts"
-dependencies:
-  - name: "generic-prometheus-alerts"
-    version: 1.9.0
-    repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,12 +32,3 @@ resources:
   memory:
     limit: 1200Mi
     request: 350Mi
-
-generic-prometheus-alerts:
-  targetApplication: court-case-matcher
-  alertSeverity: probation_in_court_alerts_dev
-  businessHoursOnly: true
-  sqsNumberAlertQueueNames:
-    - "probation-in-court-team-development-court-case-matcher-queue"
-    - "probation-in-court-team-development-court-case-matcher-dead-letter-queue"
-  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -32,12 +32,3 @@ resources:
   memory:
     limit: 2Gi
     request: 1Gi
-
-generic-prometheus-alerts:
-  targetApplication: court-case-matcher
-  alertSeverity: probation_in_court_alerts_preprod
-  businessHoursOnly: true
-  sqsNumberAlertQueueNames:
-    - "probation-in-court-team-preprod-court-case-matcher-queue"
-    - "probation-in-court-team-preprod-court-case-matcher-dead-letter-queue"
-  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -33,11 +33,3 @@ resources:
   memory:
     limit: 2Gi
     request: 1Gi
-
-generic-prometheus-alerts:
-  targetApplication: court-case-matcher
-  alertSeverity: probation_in_court_alerts_prod
-  sqsNumberAlertQueueNames:
-    - "probation-in-court-prod-court-case-matcher-queue"
-    - "probation-in-court-prod-court-case-matcher-dead-letter-queue"
-  sqsAlertsTotalMessagesThreshold: 1


### PR DESCRIPTION
This reverts commit 1b4b70099258805a78bfe884b9a6905080a6cd13.

Failed to deploy unfortunately.
Suggested course is to upgrade charts to helm v2 and use the generic-service helm chart before attempting this again