### PR TITLE
PIC-4145 Remove unused app insights dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import java.time.Instant
 import java.time.LocalDate
 
 plugins {
@@ -80,8 +79,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
 
-    implementation 'com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.4'
-    implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
 
     implementation 'jakarta.validation:jakarta.validation-api:3.1.0'
@@ -115,8 +112,6 @@ dependencies {
 
     testImplementation 'au.com.dius.pact.consumer:junit5:4.3.15'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
-
-    agentDeps 'com.microsoft.azure:applicationinsights-agent:3.4.10'
 }
 
 test {


### PR DESCRIPTION
remove unused app insights dependencies after we included `uk.gov.justice.hmpps.gradle-spring-boot`

Remove agentDeps as this is brought in by `uk.gov.justice.hmpps.gradle-spring-boot`

Hopefully resolving this error 
` ERROR c.m.applicationinsights.agent - Application Insights Java Agent 3.4.10 startup failed (PID 1)`