### PR TITLE
PIC-4207 Update UTC date to BST+1

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/ReplayHearingsService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/ReplayHearingsService.java
@@ -61,11 +61,13 @@ public class ReplayHearingsService {
                     try {
                         String id = hearing.getId();
                         String s3Path = hearing.getS3Path();
-                        LocalDateTime received = hearing.getReceived(); // THIS IS UTC and therefore 1 hour behind the time in the S3 path
+                        LocalDateTime received = hearing.getReceived().plusHours(1); // THIS IS UTC and therefore 1 hour behind the time in the S3 path
 
                         courtCaseServiceClient.getHearing(id).blockOptional().ifPresentOrElse(
                             (existingHearing) -> {
                                 // check court-case-service and compare the last updated date with the inputted-hearing
+
+                                // existingHearing.getLastUpdated() is using UK timezone (BST)
                                 if (existingHearing.getLastUpdated().isBefore(received)) {
                                     log.info("Processing hearing {} as it has not been updated since {}", id, existingHearing.getLastUpdated());
                                     processNewOrUpdatedHearing(s3Path, id);


### PR DESCRIPTION
Add an hour to the hearing timestamp we get from the csv

This is because the court-case-service hearing.lastUpdated date is using BST UK timezone.

In order to compare the CSV hearing timestamp to ccs hearing we need to make both dates BST