### PR TITLE
PIC-4207 Deny requests to 404hearings

### DIFF
--- a/helm_deploy/court-case-matcher/templates/ingress.yaml
+++ b/helm_deploy/court-case-matcher/templates/ingress.yaml
@@ -20,11 +20,11 @@ metadata:
     # Secure the retry all dlqs endpoint from outside of the Kubernetes ingress
     nginx.ingress.kubernetes.io/configuration-snippet: |
       server_tokens off;
-      location /{{ template "app.fullname" . }}/queue-admin/retry-all-dlqs {
+      location /queue-admin/retry-all-dlqs {
         deny all;
         return 401;
       }
-      location /{{ template "app.fullname" . }}/replay404Hearings {
+      location /replay404Hearings {
         deny all;
         return 401;
       }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/service/ReplayHearingsService.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/service/ReplayHearingsService.java
@@ -81,12 +81,14 @@ public class ReplayHearingsService {
                                 processNewOrUpdatedHearing(s3Path, id);
                             }
                         );
-                        log.info("Processed hearing number {} of {}", ++count, numberToProcess);
                     }
                     catch (Exception e) {
                         log.error("Error processing hearing with id {}", hearing.getId());
                         log.error(e.getMessage());
                         trackHearingProcessedEvent(hearing.getId(), "failed");
+                    }
+                    finally {
+                        log.info("Processed hearing number {} of {}", ++count, numberToProcess);
                     }
                 }
                 log.info("Processing complete. {} of {} processed",count,numberToProcess);


### PR DESCRIPTION
Deny requests to /replay404Hearings on the ingress

Update ingress to block `/queue-admin/retry-all-dlqs` calls

Move log into the finally block of try/catch