### PR TITLE
PIC-4150 Build gradle and use multi-stage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
+FROM openjdk:21-jdk-slim-buster AS builder
+
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+
+WORKDIR /app
+ADD . .
+RUN ./gradlew --no-daemon assemble
+
 FROM openjdk:21-jdk-slim-buster
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
+
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
 ENV TZ=Europe/London
 RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
@@ -7,15 +19,12 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezo
 RUN groupadd --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000
 
-RUN mkdir -p /app
 WORKDIR /app
 
-COPY build/libs/court-case-matcher-*.jar /app/court-case-matcher.jar
-COPY build/libs/applicationinsights-agent*.jar /app/agent.jar
-COPY applicationinsights.json /app
-COPY run.sh /app
-
-RUN chown -R appuser:appgroup /app
+COPY --from=builder --chown=appuser:appgroup /app/build/libs/court-case-matcher-*.jar /app/court-case-matcher.jar
+COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
+COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
+COPY --from=builder --chown=appuser:appgroup /app/run.sh /app
 
 USER 2000
 


### PR DESCRIPTION
Build gradle in the Dockerfile. This unblocks usage of hmpps circleci orb for build_docker

Use multi-stage Dockerfile to build Gradle first