### PR TITLE
PIC-4147 Add generic-prometheus-alerts

### DIFF
--- a/helm_deploy/court-case-matcher/Chart.yaml
+++ b/helm_deploy/court-case-matcher/Chart.yaml
@@ -7,3 +7,6 @@ dependencies:
   - name: generic-service
     version: 3.6.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
+  - name: generic-prometheus-alerts
+    version: 1.11.3
+    repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/court-case-matcher/values.yaml
+++ b/helm_deploy/court-case-matcher/values.yaml
@@ -82,3 +82,6 @@ generic-service:
     requests:
       cpu: 100m
       memory: 1Gi
+
+generic-prometheus-alerts:
+  targetApplication: court-case-matcher

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,3 +10,6 @@ generic-service:
 
   env:
     SPRING_PROFILES_ACTIVE: "dev,instrumented"
+
+generic-prometheus-alerts:
+  alertSeverity: probation_in_court_alerts_dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,3 +10,6 @@ generic-service:
 
   env:
     SPRING_PROFILES_ACTIVE: "preprod,instrumented"
+
+generic-prometheus-alerts:
+  alertSeverity: probation_in_court_alerts_preprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,9 +16,7 @@ generic-prometheus-alerts:
     sqsNumberAlertQueueNames:
       - probation-in-court-prod-court-case-matcher-dead-letter-queue
       - probation-in-court-prod-court-cases-dlq.fifo
-      - probation-in-court-prod-pic_new_offender_events_dlq
     sqsOldestAlertQueueNames:
       - probation-in-court-prod-court-case-matcher-queue
       - probation-in-court-prod-court-cases.fifo
-      - probation-in-court-prod-pic_new_offender_events_queue
     sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,3 +10,15 @@ generic-service:
 
   env:
     SPRING_PROFILES_ACTIVE: "prod,instrumented"
+
+generic-prometheus-alerts:
+    alertSeverity: probation_in_court_alerts_prod
+    sqsNumberAlertQueueNames:
+      - probation-in-court-prod-court-case-matcher-dead-letter-queue
+      - probation-in-court-prod-court-cases-dlq.fifo
+      - probation-in-court-prod-pic_new_offender_events_dlq
+    sqsOldestAlertQueueNames:
+      - probation-in-court-prod-court-case-matcher-queue
+      - probation-in-court-prod-court-cases.fifo
+      - probation-in-court-prod-pic_new_offender_events_queue
+    sqsAlertsTotalMessagesThreshold: 1


### PR DESCRIPTION
Add the generic-prometheus alerts. 

Include alerts related to the AWS queues.

Set the aws queue alert threshold to 1. This can be adjusted if need be.