### PR TITLE
Fix connection issues with reactor

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/application/WebConfig.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/application/WebConfig.java
@@ -13,7 +13,9 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -42,6 +44,21 @@ public class WebConfig {
 
     @Value("${web.client.write-timeout-ms}")
     private int writeTimeoutMs;
+
+    @Value("${web.client.max-connections}")
+    private int maxConnections;
+
+    @Value("${web.client.max-idle-time-ms}")
+    private int maxIdleTimeMs;
+
+    @Value("${web.client.max-life-time-ms}")
+    private int maxLifeTimeMs;
+
+    @Value("${web.client.pending-acquire-timeout-ms}")
+    private int pendingAcquireTimeoutMs;
+
+    @Value("${web.client.evict-in-background-ms}")
+    private int evictInBackgroundMs;
 
     @Bean
     public WebClient courtCaseServiceWebClient(OAuth2AuthorizedClientManager authorizedClientManager) {
@@ -96,12 +113,16 @@ public class WebConfig {
     }
 
     private WebClient.Builder defaultWebClientBuilder() {
-        HttpClient httpClient = HttpClient.create()
-            .tcpConfiguration(client ->
-                client.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
-                    .doOnConnected(conn -> conn
-                        .addHandlerLast(new ReadTimeoutHandler(readTimeoutMs, TimeUnit.MILLISECONDS))
-                        .addHandlerLast(new WriteTimeoutHandler(writeTimeoutMs, TimeUnit.MILLISECONDS))));
+        ConnectionProvider connectionProvider = ConnectionProvider.builder("custom")
+            .maxConnections(maxConnections)
+            .maxIdleTime(Duration.ofMillis(maxIdleTimeMs))
+            .maxLifeTime(Duration.ofMillis(maxLifeTimeMs))
+            .pendingAcquireTimeout(Duration.ofMillis(pendingAcquireTimeoutMs))
+            .evictInBackground(Duration.ofMillis(evictInBackgroundMs)).build();
+
+        HttpClient httpClient = HttpClient.create(connectionProvider)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
+            .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(readTimeoutMs, TimeUnit.MILLISECONDS)).addHandlerLast(new WriteTimeoutHandler(writeTimeoutMs, TimeUnit.MILLISECONDS)));
 
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,6 +99,11 @@ web:
     connect-timeout-ms: 20000
     read-timeout-ms: 20000
     write-timeout-ms: 20000
+    max-connections: 100
+    max-idle-time-ms: 20000
+    max-life-time-ms: 60000
+    pending-acquire-timeout-ms: 60000
+    evict-in-background-ms: 120000
 
 # Libra feed has today's case list and another case list for this many days hence. e.g. 25th and 28th July
 case-feed-future-date-offset: 3


### PR DESCRIPTION
Fix connection closed by client errors by adding connection pool timeout configurations

This will fix the below error:

`recvAddress(..) failed: Connection reset by peer`

It happens [1k times a week in Production](https://portal.azure.com/#blade/AppInsightsExtension/BladeRedirect/BladeName/searchV1/ResourceId/%252Fsubscriptions%252Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%252FresourceGroups%252Fnomisapi-prod-rg%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fnomisapi-prod/BladeInputs/%7B%22tables%22%3A%5B%22availabilityResults%22%2C%22customEvents%22%2C%22dependencies%22%2C%22exceptions%22%2C%22pageViews%22%2C%22requests%22%2C%22traces%22%5D%2C%22timeContextWhereClause%22%3A%22%7C%20where%20timestamp%20%3E%20datetime(%5C%222024-11-05T18%3A14%3A28.964Z%5C%22)%20and%20timestamp%20%3C%20datetime(%5C%222024-11-12T18%3A14%3A28.964Z%5C%22)%22%2C%22filterWhereClause%22%3A%22%7C%20where%20cloud_RoleName%20in%20(%5C%22court-case-matcher%5C%22)%7C%20where%20*%20has%20%5C%22recvAddress%5C%22%7C%20order%20by%20timestamp%20desc%22%2C%22originalParams%22%3A%7B%22eventTypes%22%3A%5B%7B%22value%22%3A%22availabilityResult%22%2C%22tableName%22%3A%22availabilityResults%22%2C%22label%22%3A%22Availability%22%7D%2C%7B%22value%22%3A%22customEvent%22%2C%22tableName%22%3A%22customEvents%22%2C%22label%22%3A%22Custom%20Event%22%7D%2C%7B%22value%22%3A%22dependency%22%2C%22tableName%22%3A%22dependencies%22%2C%22label%22%3A%22Dependency%22%7D%2C%7B%22value%22%3A%22exception%22%2C%22tableName%22%3A%22exceptions%22%2C%22label%22%3A%22Exception%22%7D%2C%7B%22value%22%3A%22pageView%22%2C%22tableName%22%3A%22pageViews%22%2C%22label%22%3A%22Page%20View%22%7D%2C%7B%22value%22%3A%22request%22%2C%22tableName%22%3A%22requests%22%2C%22label%22%3A%22Request%22%7D%2C%7B%22value%22%3A%22trace%22%2C%22tableName%22%3A%22traces%22%2C%22label%22%3A%22Trace%22%7D%5D%2C%22timeContext%22%3A%7B%22durationMs%22%3A604800000%7D%2C%22filter%22%3A%5B%7B%22dimension%22%3A%7B%22displayName%22%3A%22Cloud%20role%20name%22%2C%22tables%22%3A%5B%22availabilityResults%22%2C%22requests%22%2C%22exceptions%22%2C%22pageViews%22%2C%22traces%22%2C%22customEvents%22%2C%22dependencies%22%5D%2C%22name%22%3A%22cloud%2FroleName%22%2C%22draftKey%22%3A%22cloud%2FroleName%22%7D%2C%22values%22%3A%5B%22court-case-matcher%22%5D%2C%22operator%22%3A%7B%22label%22%3A%22%3D%22%2C%22value%22%3A%22%3D%3D%22%2C%22isSelected%22%3Atrue%7D%7D%5D%2C%22searchPhrase%22%3A%7B%22originalPhrase%22%3A%22recvAddress%22%2C%22_tokens%22%3A%5B%7B%22conjunction%22%3A%22and%22%2C%22value%22%3A%22recvAddress%22%2C%22isNot%22%3Afalse%2C%22kql%22%3A%22%20*%20has%20%5C%22recvAddress%5C%22%22%7D%5D%7D%2C%22sort%22%3A%22desc%22%7D%7D)

You can find a PR on Github: **reactor/reactor-netty** **issues/1774**

These configurations can be adjusted. I think we'd also want to do performance testing to make sure it doesn't slow things down.

My assumption is that when calling GET /hearing/{id} on court-case-service it tries to use a connection that was closed by a peer but left in the connection pool 👀 🤔 

**More information:**

https://projectreactor.io/docs/netty/release/reference/appendices.html#faq.connection-closed