### PR TITLE
PIC-4243 Enable info endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/security/OAuth2SecurityConfig.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/security/OAuth2SecurityConfig.java
@@ -26,7 +26,7 @@ public class OAuth2SecurityConfig {
             .and().oauth2Client()
             .and()
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers( "/health/**","/queue-admin/retry-all-dlqs", "/replay404Hearings").permitAll()
+                .requestMatchers( "/health/**","/queue-admin/retry-all-dlqs", "/replay404Hearings", "/info").permitAll()
                 .anyRequest().hasRole(role))
             .oauth2ResourceServer().jwt().jwtAuthenticationConverter(new AuthAwareTokenConverter());
         http.anonymous();

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,18 +34,16 @@ nomis-oauth:
 person-record-service:
   base-url: http://localhost:8083/
 
-hmpps:
-  sqs:
-    enabled: true
-    provider: localstack
-    queues:
-      courtcasematcherqueue:
-        queueName: court-case-matcher-queue
-        subscribeTopicId: courtcaseeventstopic
-  sns:
-    topics:
-      courtcaseeventstopic:
-        arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+hmpps.sqs:
+  enabled: true
+  provider: localstack
+  queues:
+    courtcasematcherqueue:
+      queueName: court-case-matcher-queue
+      subscribeTopicId: courtcaseeventstopic
+  topics:
+    courtcaseeventstopic:
+      arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
 
 feature:
   flags:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,8 @@ management:
       exposure:
         include: health,info
   endpoint:
+    info:
+      enabled: true
     health:
       show-details: always
       path-mapping: "health"

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/application/TestMessagingConfig.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/application/TestMessagingConfig.java
@@ -28,9 +28,4 @@ public class TestMessagingConfig {
             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
             .build();
     }
-
-    @MockBean
-    private BuildProperties buildProperties;
-
-
 }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/info/InfoTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/info/InfoTest.java
@@ -1,0 +1,42 @@
+package uk.gov.justice.probation.courtcasematcher.info;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.justice.probation.courtcasematcher.TestConfig;
+import uk.gov.justice.probation.courtcasematcher.application.TestMessagingConfig;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockExtension;
+import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockMockServer;
+
+import static io.restassured.RestAssured.given;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(TestMessagingConfig.class)
+public class InfoTest {
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void before() {
+        TestConfig.configureRestAssuredForIntTest(port);
+    }
+
+    @Test
+    public void testUp() {
+        String response = given()
+            .when()
+            .get("/info")
+            .then()
+            .statusCode(200)
+            .extract().response().asString();
+
+        assertThatJson(response).node("git").isPresent();
+        assertThatJson(response).node("build").isPresent();
+    }
+}

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/info/InfoTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/info/InfoTest.java
@@ -2,15 +2,12 @@ package uk.gov.justice.probation.courtcasematcher.info;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.justice.probation.courtcasematcher.TestConfig;
 import uk.gov.justice.probation.courtcasematcher.application.TestMessagingConfig;
-import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockExtension;
-import uk.gov.justice.probation.courtcasematcher.wiremock.WiremockMockServer;
 
 import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;


### PR DESCRIPTION
Enable `/info` endpoint

Allow public access to info endpoint

This will reduce errors on court-case-matcher which was called by the [developer-portal](https://developer-portal.hmpps.service.justice.gov.uk/components/court-case-matcher/environment/dev)