### PR TITLE
PIC-4522 Set DOB to null if not in past

### DIFF
--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/model/offendersearch/MatchRequest.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/model/offendersearch/MatchRequest.java
@@ -54,7 +54,7 @@ public class MatchRequest {
                                                 .pncNumber(pnc)
                                                 .surname(fullName.getSurname());
 
-            if (!dateOfBirth.isBefore(LocalDate.now())){
+            if (!Objects.isNull(dateOfBirth) & !dateOfBirth.isBefore(LocalDate.now())){
                 log.warn("Defendant date of birth is not in the past, setting to null");
                 dateOfBirth = null;
             }

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/model/offendersearch/MatchRequest.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/model/offendersearch/MatchRequest.java
@@ -53,6 +53,12 @@ public class MatchRequest {
             MatchRequestBuilder builder = builder()
                                                 .pncNumber(pnc)
                                                 .surname(fullName.getSurname());
+
+            if (!dateOfBirth.isBefore(LocalDate.now())){
+                log.warn("Defendant date of birth is not in the past, setting to null");
+                dateOfBirth = null;
+            }
+
             if (!Objects.isNull(dateOfBirth)) {
                 if (useDobWithPnc || isBlank(pnc)) {
                     builder.dateOfBirth(dateOfBirth.format(DateTimeFormatter.ISO_DATE));

--- a/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/model/offendersearch/MatchRequest.java
+++ b/src/main/java/uk/gov/justice/probation/courtcasematcher/restclient/model/offendersearch/MatchRequest.java
@@ -54,7 +54,7 @@ public class MatchRequest {
                                                 .pncNumber(pnc)
                                                 .surname(fullName.getSurname());
 
-            if (!Objects.isNull(dateOfBirth) & !dateOfBirth.isBefore(LocalDate.now())){
+            if (!Objects.isNull(dateOfBirth) && !dateOfBirth.isBefore(LocalDate.now())){
                 log.warn("Defendant date of birth is not in the past, setting to null");
                 dateOfBirth = null;
             }

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientIntTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/restclient/OffenderSearchRestClientIntTest.java
@@ -61,6 +61,27 @@ public class OffenderSearchRestClientIntTest {
         }
 
         @Test
+        public void givenInvalidDob_AndSingleMatchReturned_whenMatch_thenReturnIt() {
+            var name = uk.gov.justice.probation.courtcasematcher.model.domain.Name.builder().forename1("Arthur").surname("MORGAN").build();
+            var match = restClient.match(matchRequestFactory.buildFrom("2004/0012345U", name, LocalDate.now())).blockOptional();
+
+            assertThat(match).isPresent();
+            assertThat(match.get().getMatchedBy()).isEqualTo(OffenderSearchMatchType.ALL_SUPPLIED);
+            assertThat(match.get().getMatches().size()).isEqualTo(1);
+            assertThat(match.get().isExactOffenderMatch()).isTrue();
+
+            var offender = match.get().getMatches().get(0).getOffender();
+            assertThat(offender.getOtherIds().getCrn()).isEqualTo("X346204");
+            assertThat(offender.getOtherIds().getCroNumber()).isEqualTo("1234ABC");
+            assertThat(offender.getOtherIds().getPncNumber()).isEqualTo("2004/0012345U");
+            assertThat(offender.getProbationStatus().getStatus()).isEqualTo("CURRENT");
+            assertThat(offender.getProbationStatus().getInBreach()).isTrue();
+            assertThat(offender.getProbationStatus().isPreSentenceActivity()).isFalse();
+            assertThat(offender.getProbationStatus().isAwaitingPsr()).isFalse();
+            assertThat(offender.getProbationStatus().getPreviouslyKnownTerminationDate()).isEqualTo(LocalDate.of(2020, Month.FEBRUARY, 2));
+        }
+
+        @Test
         public void givenSingleMatchReturned_whenMatchWithPncNoDob_thenReturnIt() {
             var name = uk.gov.justice.probation.courtcasematcher.model.domain.Name.builder().forename1("Arthur").surname("MORGAN").build();
             var match = restClient.match(matchRequestFactory.buildFrom("2004/0012345U", name, LocalDate.of(1975, 1, 1))).blockOptional();

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -78,12 +78,6 @@ class MatcherServiceTest {
             .surname("MORGAN")
             .dateOfBirth("2000-06-17")
             .build();
-    private final MatchRequest matchRequestTodayDob = MatchRequest.builder()
-        .pncNumber(PNC)
-        .firstName("Arthur")
-        .surname("MORGAN")
-        .dateOfBirth(null)
-        .build();
     private final MatchRequest matchRequest2 = MatchRequest.builder()
             .pncNumber(PNC_2)
             .firstName("John")
@@ -247,33 +241,6 @@ class MatcherServiceTest {
         personMatchScoreReq2.setDateOfBirth(PersonMatchScoreParameter.of(null, null));
         verify(personMatchScoreRestClient, times(2)).match(AdditionalMatchers.or(
                 eq(personMatchScoreReq1), eq(personMatchScoreReq2)));
-    }
-
-    @Test
-    void givenDateOfBirthNotInPast_shouldSetToNull_AndAllowMatchingOfDefendantsWithNullDateOfBirth() {
-        // Given
-        defendant1.setDateOfBirth(LocalDate.now());
-        defendant2.setDateOfBirth(null);
-        matchRequest2.setDateOfBirth(null);
-
-        when(matchRequestFactory.buildFrom(defendant1)).thenReturn(matchRequestTodayDob);
-        when(matchRequestFactory.buildFrom(defendant2)).thenReturn(matchRequest2);
-        when(offenderSearchRestClient.match(matchRequestTodayDob)).thenReturn(Mono.just(multipleExactMatches));
-        when(offenderSearchRestClient.match(matchRequest2)).thenReturn(Mono.just(noMatches));
-
-        when(personMatchScoreRestClient.match(any()))
-            .thenReturn(Mono.just(PersonMatchScoreResponse.builder().matchProbability(PersonMatchScoreParameter.of(0.91, null)).build()))
-            .thenReturn(Mono.just(PersonMatchScoreResponse.builder().matchProbability(PersonMatchScoreParameter.of(0.81, null)).build()));
-
-        // When
-        matcherService.matchDefendants(hearing).block();
-
-        // Then
-        personMatchScoreReq1.setDateOfBirth(PersonMatchScoreParameter.of(null, "2025-02-11"));
-        personMatchScoreReq2.setDateOfBirth(PersonMatchScoreParameter.of(null, "2025-02-11"));
-
-        verify(personMatchScoreRestClient, times(2)).match(AdditionalMatchers.or(
-            eq(personMatchScoreReq1), eq(personMatchScoreReq2)));
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
+++ b/src/test/java/uk/gov/justice/probation/courtcasematcher/service/MatcherServiceTest.java
@@ -78,6 +78,12 @@ class MatcherServiceTest {
             .surname("MORGAN")
             .dateOfBirth("2000-06-17")
             .build();
+    private final MatchRequest matchRequestTodayDob = MatchRequest.builder()
+        .pncNumber(PNC)
+        .firstName("Arthur")
+        .surname("MORGAN")
+        .dateOfBirth(null)
+        .build();
     private final MatchRequest matchRequest2 = MatchRequest.builder()
             .pncNumber(PNC_2)
             .firstName("John")
@@ -241,6 +247,33 @@ class MatcherServiceTest {
         personMatchScoreReq2.setDateOfBirth(PersonMatchScoreParameter.of(null, null));
         verify(personMatchScoreRestClient, times(2)).match(AdditionalMatchers.or(
                 eq(personMatchScoreReq1), eq(personMatchScoreReq2)));
+    }
+
+    @Test
+    void givenDateOfBirthNotInPast_shouldSetToNull_AndAllowMatchingOfDefendantsWithNullDateOfBirth() {
+        // Given
+        defendant1.setDateOfBirth(LocalDate.now());
+        defendant2.setDateOfBirth(null);
+        matchRequest2.setDateOfBirth(null);
+
+        when(matchRequestFactory.buildFrom(defendant1)).thenReturn(matchRequestTodayDob);
+        when(matchRequestFactory.buildFrom(defendant2)).thenReturn(matchRequest2);
+        when(offenderSearchRestClient.match(matchRequestTodayDob)).thenReturn(Mono.just(multipleExactMatches));
+        when(offenderSearchRestClient.match(matchRequest2)).thenReturn(Mono.just(noMatches));
+
+        when(personMatchScoreRestClient.match(any()))
+            .thenReturn(Mono.just(PersonMatchScoreResponse.builder().matchProbability(PersonMatchScoreParameter.of(0.91, null)).build()))
+            .thenReturn(Mono.just(PersonMatchScoreResponse.builder().matchProbability(PersonMatchScoreParameter.of(0.81, null)).build()));
+
+        // When
+        matcherService.matchDefendants(hearing).block();
+
+        // Then
+        personMatchScoreReq1.setDateOfBirth(PersonMatchScoreParameter.of(null, "2025-02-11"));
+        personMatchScoreReq2.setDateOfBirth(PersonMatchScoreParameter.of(null, "2025-02-11"));
+
+        verify(personMatchScoreRestClient, times(2)).match(AdditionalMatchers.or(
+            eq(personMatchScoreReq1), eq(personMatchScoreReq2)));
     }
 
     @Test


### PR DESCRIPTION
Set the defendant date of birth to null if it is not in the past

This fixes a failure when calling the offender search api that requires the defendant dob to be in the past or it'll return a 400 BAD Request error. We have a FIFO event driven architecture so 1 message stuck on the queue leads to a blockage.

See here https://github.com/ministryofjustice/probation-offender-search/blob/69396dc73e71921848b499205689ab24610f25f0/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/dto/MatchRequest.kt#L13